### PR TITLE
[SHK-61] FeedLike 등록, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
@@ -1,6 +1,8 @@
 package com.prgrms.kream.common.mapper;
 
-import com.prgrms.kream.domain.member.model.Member;
+import com.prgrms.kream.domain.style.dto.request.LikeFeedFacadeRequest;
+import com.prgrms.kream.domain.style.dto.request.LikeFeedRequest;
+import com.prgrms.kream.domain.style.dto.request.LikeFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedFacadeRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedServiceRequest;
@@ -14,6 +16,7 @@ import com.prgrms.kream.domain.style.dto.response.UpdateFeedFacadeResponse;
 import com.prgrms.kream.domain.style.dto.response.UpdateFeedResponse;
 import com.prgrms.kream.domain.style.dto.response.UpdateFeedServiceResponse;
 import com.prgrms.kream.domain.style.model.Feed;
+import com.prgrms.kream.domain.style.model.FeedLike;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -25,23 +28,23 @@ public class StyleMapper {
 	) {
 		return new RegisterFeedFacadeRequest(
 				registerFeedRequest.content(),
-				registerFeedRequest.author(),
+				registerFeedRequest.authorId(),
 				registerFeedRequest.images()
 		);
 	}
 
 	public static RegisterFeedServiceRequest toRegisterFeedServiceRequest(
-			RegisterFeedFacadeRequest registerFeedFacadeRequest, Member author) {
+			RegisterFeedFacadeRequest registerFeedFacadeRequest) {
 		return new RegisterFeedServiceRequest(
 				registerFeedFacadeRequest.content(),
-				author
+				registerFeedFacadeRequest.authorId()
 		);
 	}
 
 	public static Feed toFeed(RegisterFeedServiceRequest registerFeedServiceRequest) {
 		return Feed.builder()
 				.content(registerFeedServiceRequest.content())
-				.author(registerFeedServiceRequest.author())
+				.authorId(registerFeedServiceRequest.authorId())
 				.build();
 	}
 
@@ -76,6 +79,23 @@ public class StyleMapper {
 
 	public static UpdateFeedResponse toUpdateFeedResponse(UpdateFeedFacadeResponse updateFeedFacadeResponse) {
 		return new UpdateFeedResponse(updateFeedFacadeResponse.id());
+	}
+
+	public static LikeFeedFacadeRequest toLikeFeedFacadeRequest(long id, LikeFeedRequest likeFeedRequest) {
+		return new LikeFeedFacadeRequest(id, likeFeedRequest.memberId());
+	}
+
+	public static LikeFeedServiceRequest toLikeFeedServiceRequest(LikeFeedFacadeRequest likeFeedFacadeRequest) {
+		return new LikeFeedServiceRequest(
+				likeFeedFacadeRequest.feedId(),
+				likeFeedFacadeRequest.memberId());
+	}
+
+	public static FeedLike toFeedLike(LikeFeedServiceRequest likeFeedServiceRequest) {
+		return FeedLike.builder()
+				.feedId(likeFeedServiceRequest.feedId())
+				.memberId(likeFeedServiceRequest.memberId())
+				.build();
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
+++ b/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.kream.common.api.ApiResponse;
+import com.prgrms.kream.domain.style.dto.request.LikeFeedRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedRequest;
 import com.prgrms.kream.domain.style.dto.request.UpdateFeedRequest;
 import com.prgrms.kream.domain.style.dto.response.RegisterFeedResponse;
@@ -65,4 +66,29 @@ public class StyleController {
 		styleFacade.delete(id);
 	}
 
+	@PostMapping("/{id}/like")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void registerFeedLike(
+			@PathVariable long id,
+			@RequestBody @Valid LikeFeedRequest likeFeedRequest) {
+		styleFacade.registerFeedLike(
+				toLikeFeedFacadeRequest(
+						id,
+						likeFeedRequest
+				)
+		);
+	}
+
+	@DeleteMapping("/{id}/like")
+	@ResponseStatus(HttpStatus.OK)
+	public void deleteFeedLike(
+			@PathVariable long id,
+			@RequestBody @Valid LikeFeedRequest likeFeedRequest) {
+		styleFacade.deleteFeedLike(
+				toLikeFeedFacadeRequest(
+						id,
+						likeFeedRequest
+				)
+		);
+	}
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/LikeFeedFacadeRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/LikeFeedFacadeRequest.java
@@ -1,0 +1,7 @@
+package com.prgrms.kream.domain.style.dto.request;
+
+public record LikeFeedFacadeRequest(
+		Long feedId,
+		Long memberId
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/LikeFeedRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/LikeFeedRequest.java
@@ -1,0 +1,11 @@
+package com.prgrms.kream.domain.style.dto.request;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+public record LikeFeedRequest(
+		@NotNull(message = "사용자 식별값은 비어있을 수 없습니다.")
+		@Positive(message = "사용자 식별값이 올바르지 않습니다.")
+		Long memberId
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/LikeFeedServiceRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/LikeFeedServiceRequest.java
@@ -1,0 +1,7 @@
+package com.prgrms.kream.domain.style.dto.request;
+
+public record LikeFeedServiceRequest(
+		Long feedId,
+		Long memberId
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedFacadeRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedFacadeRequest.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public record RegisterFeedFacadeRequest(
 		String content,
-		Long author,
+		Long authorId,
 		List<MultipartFile> images
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedRequest.java
@@ -13,7 +13,7 @@ public record RegisterFeedRequest(
 		String content,
 		@NotNull(message = "작성자 식별값은 비어있을 수 없습니다.")
 		@Positive(message = "작성자 식별값이 올바르지 않습니다.")
-		Long author,
+		Long authorId,
 		List<MultipartFile> images
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedServiceRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedServiceRequest.java
@@ -1,9 +1,7 @@
 package com.prgrms.kream.domain.style.dto.request;
 
-import com.prgrms.kream.domain.member.model.Member;
-
 public record RegisterFeedServiceRequest(
 		String content,
-		Member author
+		Long authorId
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.prgrms.kream.domain.image.model.DomainType;
 import com.prgrms.kream.domain.image.service.ImageService;
 import com.prgrms.kream.domain.member.service.MemberService;
+import com.prgrms.kream.domain.style.dto.request.LikeFeedFacadeRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedFacadeRequest;
 import com.prgrms.kream.domain.style.dto.request.UpdateFeedFacadeRequest;
 import com.prgrms.kream.domain.style.dto.response.RegisterFeedFacadeResponse;
@@ -30,10 +31,7 @@ public class StyleFacade {
 	public RegisterFeedFacadeResponse register(RegisterFeedFacadeRequest registerFeedFacadeRequest) {
 		RegisterFeedFacadeResponse registerFeedFacadeResponse = toRegisterFeedFacadeResponse(
 				styleService.register(
-						toRegisterFeedServiceRequest(
-								registerFeedFacadeRequest,
-								memberService.getMember(registerFeedFacadeRequest.author())
-						)
+						toRegisterFeedServiceRequest(registerFeedFacadeRequest)
 				)
 		);
 
@@ -60,6 +58,20 @@ public class StyleFacade {
 	@Transactional
 	public void delete(long id) {
 		styleService.delete(id);
+	}
+
+	@Transactional
+	public void registerFeedLike(LikeFeedFacadeRequest likeFeedFacadeRequest) {
+		styleService.registerFeedLike(
+				toLikeFeedServiceRequest(likeFeedFacadeRequest)
+		);
+	}
+
+	@Transactional
+	public void deleteFeedLike(LikeFeedFacadeRequest likeFeedFacadeRequest) {
+		styleService.deleteFeedLike(
+				toLikeFeedServiceRequest(likeFeedFacadeRequest)
+		);
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/model/Feed.java
+++ b/src/main/java/com/prgrms/kream/domain/style/model/Feed.java
@@ -5,12 +5,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import com.prgrms.kream.common.model.BaseTimeEntity;
-import com.prgrms.kream.domain.member.model.Member;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,15 +27,14 @@ public class Feed extends BaseTimeEntity {
 	@Column(name = "content", nullable = false, unique = false, length = 255)
 	private String content;
 
-	@ManyToOne
-	@JoinColumn(name = "author_id", nullable = false, unique = false)
-	private Member author;
+	@Column(name = "author_id", nullable = false, unique = false)
+	private Long authorId;
 
 	@Builder
-	public Feed(Long id, String content, Member author) {
+	public Feed(Long id, String content, Long authorId) {
 		this.id = id;
 		this.content = content;
-		this.author = author;
+		this.authorId = authorId;
 	}
 
 	public void updateContent(String content) {

--- a/src/main/java/com/prgrms/kream/domain/style/model/FeedLike.java
+++ b/src/main/java/com/prgrms/kream/domain/style/model/FeedLike.java
@@ -16,9 +16,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "feed_tag")
+@Table(name = "feed_like")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FeedTag extends BaseTimeEntity {
+public class FeedLike extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,14 +27,14 @@ public class FeedTag extends BaseTimeEntity {
 	@Column(name = "feed_id", nullable = false, unique = false)
 	private Long feedId;
 
-	@Column(name = "tag", nullable = false, unique = false, length = 20)
-	private String tag;
+	@Column(name = "member_id", nullable = false, unique = false)
+	private Long memberId;
 
 	@Builder
-	public FeedTag(Long id, Long feedId, String tag) {
+	public FeedLike(Long id, Long feedId, Long memberId) {
 		this.id = id;
 		this.feedId = feedId;
-		this.tag = tag;
+		this.memberId = memberId;
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedLikeRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedLikeRepository.java
@@ -1,0 +1,17 @@
+package com.prgrms.kream.domain.style.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.kream.domain.style.model.FeedLike;
+
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+
+	long countByFeedId(Long feedId);
+
+	boolean existsByFeedIdAndMemberId(Long feedId, Long memberId);
+
+	void deleteAllByFeedId(Long feedId);
+
+	void deleteByFeedIdAndMemberId(Long feedId, Long memberId);
+
+}

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedTagRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedTagRepository.java
@@ -2,11 +2,10 @@ package com.prgrms.kream.domain.style.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.prgrms.kream.domain.style.model.Feed;
 import com.prgrms.kream.domain.style.model.FeedTag;
 
 public interface FeedTagRepository extends JpaRepository<FeedTag, Long> {
 
-	void deleteAllByFeed(Feed feed);
+	void deleteAllByFeedId(Long feedId);
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -9,12 +9,14 @@ import javax.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.kream.domain.style.dto.request.LikeFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.UpdateFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.response.RegisterFeedServiceResponse;
 import com.prgrms.kream.domain.style.dto.response.UpdateFeedServiceResponse;
 import com.prgrms.kream.domain.style.model.Feed;
 import com.prgrms.kream.domain.style.model.FeedTag;
+import com.prgrms.kream.domain.style.repository.FeedLikeRepository;
 import com.prgrms.kream.domain.style.repository.FeedRepository;
 import com.prgrms.kream.domain.style.repository.FeedTagRepository;
 
@@ -27,6 +29,8 @@ public class StyleService {
 	private final FeedRepository feedRepository;
 
 	private final FeedTagRepository feedTagRepository;
+
+	private final FeedLikeRepository feedLikeRepository;
 
 	@Transactional
 	public RegisterFeedServiceResponse register(RegisterFeedServiceRequest registerFeedServiceRequest) {
@@ -48,7 +52,7 @@ public class StyleService {
 					feed.updateContent(updateFeedServiceRequest.content());
 					Feed entity = feedRepository.save(feed);
 
-					feedTagRepository.deleteAllByFeed(entity);
+					feedTagRepository.deleteAllByFeedId(entity.getId());
 
 					Set<FeedTag> feedTags = TagExtractor.extract(entity);
 					feedTagRepository.saveAll(feedTags);
@@ -65,9 +69,28 @@ public class StyleService {
 		feedRepository.findById(id)
 				.ifPresent(feed -> {
 					// 관련 테이블의 레코드 삭제 (Cascade)
-					feedTagRepository.deleteAllByFeed(feed);
+					feedTagRepository.deleteAllByFeedId(feed.getId());
+					feedLikeRepository.deleteAllByFeedId(feed.getId());
 					feedRepository.delete(feed);
 				});
+	}
+
+	@Transactional
+	public void registerFeedLike(LikeFeedServiceRequest likeFeedServiceRequest) {
+		if (!feedLikeRepository.existsByFeedIdAndMemberId(
+				likeFeedServiceRequest.feedId(),
+				likeFeedServiceRequest.memberId()
+		)) {
+			feedLikeRepository.save(toFeedLike(likeFeedServiceRequest));
+		}
+	}
+
+	@Transactional
+	public void deleteFeedLike(LikeFeedServiceRequest likeFeedServiceRequest) {
+		feedLikeRepository.deleteByFeedIdAndMemberId(
+				likeFeedServiceRequest.feedId(),
+				likeFeedServiceRequest.memberId()
+		);
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/service/TagExtractor.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/TagExtractor.java
@@ -28,7 +28,7 @@ public class TagExtractor {
 		// 태그 변환
 		return tags.stream()
 				.map(tag -> FeedTag.builder()
-						.feed(feed)
+						.feedId(feed.getId())
 						.tag(tag)
 						.build())
 				.collect(Collectors.toUnmodifiableSet());

--- a/src/test/java/com/prgrms/kream/style/controller/StyleControllerTest.java
+++ b/src/test/java/com/prgrms/kream/style/controller/StyleControllerTest.java
@@ -17,9 +17,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.kream.MysqlTestContainer;
+import com.prgrms.kream.domain.member.model.Authority;
 import com.prgrms.kream.domain.member.model.Member;
 import com.prgrms.kream.domain.member.repository.MemberRepository;
-import com.prgrms.kream.domain.style.dto.request.UpdateFeedFacadeRequest;
+import com.prgrms.kream.domain.style.dto.request.LikeFeedRequest;
+import com.prgrms.kream.domain.style.dto.request.UpdateFeedRequest;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -44,10 +46,10 @@ class StyleControllerTest extends MysqlTestContainer {
 		Member member = Member.builder()
 				.name("김창규")
 				.email("kimc980106@naver.com")
-				.phone("010-8610-7463")
-				.password("1234")
+				.phone("01086107463")
+				.password("qwer1234!")
 				.isMale(true)
-				.authority("ADMIN")
+				.authority(Authority.ROLE_ADMIN)
 				.build();
 		memberId = memberRepository.save(member).getId();
 
@@ -61,7 +63,7 @@ class StyleControllerTest extends MysqlTestContainer {
 		mockMvc.perform(MockMvcRequestBuilders.multipart("/api/v1/feed")
 						.file(mockImage)
 						.param("content", "이 피드의 태그는 #총 #두개 입니다.")
-						.param("author", String.valueOf(memberId)))
+						.param("authorId", String.valueOf(member.getId())))
 				.andExpect(status().isCreated())
 				.andDo(print());
 	}
@@ -69,10 +71,34 @@ class StyleControllerTest extends MysqlTestContainer {
 	@Test
 	@DisplayName("피드를 수정할 수 있다.")
 	void testUpdate() throws Exception {
-		mockMvc.perform(put("/api/v1/feed/" + memberId)
+		mockMvc.perform(put("/api/v1/feed/1")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(
-								new UpdateFeedFacadeRequest("이 피드의 태그는 총 #한개 입니다.")
+								new UpdateFeedRequest("이 피드의 태그는 총 #한개 입니다.")
+						)))
+				.andExpect(status().isOk())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("피드에 사용자의 좋아요를 등록할 수 있다.")
+	void testLikeFeed() throws Exception {
+		mockMvc.perform(post("/api/v1/feed/1/like")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(
+						new LikeFeedRequest(memberId)
+				)))
+				.andExpect(status().isCreated())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("피드에 사용자의 좋아요를 등록할 수 있다.")
+	void testUnlikeFeed() throws Exception {
+		mockMvc.perform(delete("/api/v1/feed/1/like")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(
+								new LikeFeedRequest(memberId)
 						)))
 				.andExpect(status().isOk())
 				.andDo(print());


### PR DESCRIPTION
### ⛏ 작업 사항
- 다른 도메인과 객체 연관관계 제거 (Object -> Identifier)
- FeedLike 엔티티 구현
- FeedLikeRepository 메서드 정의
- 해당 기능과 관련된 각 레이어별 기능 구현
- 좋아요 등록, 삭제 기능 테스트

### 📝 작업 요약
- 피드 좋아요 등록, 삭제 기능 구현

### 💡 관련 이슈
- Resolved : [SHK-132], [SHK-138]


[SHK-132]: https://shoekream.atlassian.net/browse/SHK-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-138]: https://shoekream.atlassian.net/browse/SHK-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ