### PR TITLE
[SHK-30] Coupon 중복 지급 방지 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/kream/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/kream/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.prgrms.kream.common.exception;
 
 import java.util.NoSuchElementException;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -36,6 +37,13 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
 		log.warn("잘못된 요청", exception);
+		return ApiResponse.error(exception.getMessage());
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(DuplicateKeyException.class)
+	public ErrorResponse handleDuplicateKeyException(DuplicateKeyException exception) {
+		log.warn("중복 참여", exception);
 		return ApiResponse.error(exception.getMessage());
 	}
 }

--- a/src/main/java/com/prgrms/kream/common/mapper/CouponEventMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/CouponEventMapper.java
@@ -1,5 +1,7 @@
 package com.prgrms.kream.common.mapper;
 
+import static com.prgrms.kream.common.mapper.CouponMapper.*;
+
 import com.prgrms.kream.domain.coupon.dto.request.CouponEventServiceRequest;
 import com.prgrms.kream.domain.coupon.dto.response.CouponEventResponse;
 import com.prgrms.kream.domain.coupon.model.CouponEvent;
@@ -12,7 +14,8 @@ public class CouponEventMapper {
 
 	public static CouponEvent toCouponEvent(CouponEventServiceRequest couponEventServiceRequest) {
 		return CouponEvent.builder()
-				.coupon(couponEventServiceRequest.coupon())
+				.coupon(toCoupon(couponEventServiceRequest.couponResponse()))
+				//TODO merge 후 memberDto 로 변경
 				.member(couponEventServiceRequest.member())
 				.build();
 	}

--- a/src/main/java/com/prgrms/kream/common/mapper/CouponMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/CouponMapper.java
@@ -18,6 +18,15 @@ public class CouponMapper {
 				.build();
 	}
 
+	public static Coupon toCoupon(CouponResponse couponResponse) {
+		return Coupon.builder()
+				.id(couponResponse.id())
+				.discountValue(couponResponse.discountValue())
+				.name(couponResponse.name())
+				.amount(couponResponse.amount())
+				.build();
+	}
+
 	public static CouponResponse toCouponResponse(Coupon coupon) {
 		return new CouponResponse(
 				coupon.getId(),

--- a/src/main/java/com/prgrms/kream/domain/coupon/facade/CouponFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/coupon/facade/CouponFacade.java
@@ -28,6 +28,7 @@ public class CouponFacade {
 		CouponResponse couponResponse = couponService.getCouponById(couponEventRegisterRequest.couponId());
 
 		return couponEventService.registerCouponEvent(
-				new CouponEventServiceRequest(member, couponResponse));
+				new CouponEventServiceRequest(member, couponResponse)
+		);
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/coupon/repository/CouponEventRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/coupon/repository/CouponEventRepository.java
@@ -1,8 +1,12 @@
 package com.prgrms.kream.domain.coupon.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.prgrms.kream.domain.coupon.model.CouponEvent;
+import com.prgrms.kream.domain.member.model.Member;
 
 public interface CouponEventRepository extends JpaRepository<CouponEvent, Long> {
+	Optional<CouponEvent> findByMember(Member member);
 }

--- a/src/main/java/com/prgrms/kream/domain/coupon/service/CouponEventService.java
+++ b/src/main/java/com/prgrms/kream/domain/coupon/service/CouponEventService.java
@@ -2,12 +2,14 @@ package com.prgrms.kream.domain.coupon.service;
 
 import static com.prgrms.kream.common.mapper.CouponEventMapper.*;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 import com.prgrms.kream.domain.coupon.dto.request.CouponEventServiceRequest;
 import com.prgrms.kream.domain.coupon.dto.response.CouponEventResponse;
 import com.prgrms.kream.domain.coupon.model.CouponEvent;
 import com.prgrms.kream.domain.coupon.repository.CouponEventRepository;
+import com.prgrms.kream.domain.member.model.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,10 +19,16 @@ public class CouponEventService {
 	private final CouponEventRepository couponEventRepository;
 
 	public CouponEventResponse registerCouponEvent(CouponEventServiceRequest couponEventServiceRequest) {
-		CouponEvent savedCouponEvent = couponEventRepository.save(
-				toCouponEvent(couponEventServiceRequest)
-		);
+		if (checkOverLapApply(couponEventServiceRequest.member())) {
+			CouponEvent entity = toCouponEvent(couponEventServiceRequest);
+			CouponEvent savedCouponEvent = couponEventRepository.save(entity);
+			return toCouponEventResponse(savedCouponEvent);
+		} else {
+			throw new DuplicateKeyException("쿠폰을 중복으로 받을 수 없습니다.");
+		}
+	}
 
-		return toCouponEventResponse(savedCouponEvent);
+	private boolean checkOverLapApply(Member member) {
+		return couponEventRepository.findByMember(member).isEmpty();
 	}
 }

--- a/src/test/java/com/prgrms/kream/domain/coupon/controller/CouponEventControllerTest.java
+++ b/src/test/java/com/prgrms/kream/domain/coupon/controller/CouponEventControllerTest.java
@@ -48,4 +48,34 @@ class CouponEventControllerTest extends MysqlTestContainer {
 		resultActions.andExpect(status().isCreated());
 	}
 
+	@Test
+	@DisplayName("쿠폰 중복 발급 테스트")
+	void overLapApplyCouponEvent() throws Exception {
+		//given
+		CouponEventRegisterRequest couponEventRegisterRequest = new CouponEventRegisterRequest(1L, 1L);
+
+		//when
+		mockMvc.perform(
+				post("/api/v1/coupon")
+						.contentType(MediaType.APPLICATION_JSON)
+						.characterEncoding(StandardCharsets.UTF_8)
+						.content(
+								objectMapperBuilder.build()
+										.writeValueAsString(couponEventRegisterRequest)
+						)
+		);
+		ResultActions resultActions = mockMvc.perform(
+				post("/api/v1/coupon")
+						.contentType(MediaType.APPLICATION_JSON)
+						.characterEncoding(StandardCharsets.UTF_8)
+						.content(
+								objectMapperBuilder.build()
+										.writeValueAsString(couponEventRegisterRequest)
+						)
+		);
+
+		//then
+		resultActions.andExpect(status().isBadRequest());
+	}
+
 }

--- a/src/test/java/com/prgrms/kream/domain/coupon/service/CouponEventServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/coupon/service/CouponEventServiceTest.java
@@ -1,7 +1,10 @@
 package com.prgrms.kream.domain.coupon.service;
 
+import static com.prgrms.kream.common.mapper.CouponMapper.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,9 +13,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.dao.DuplicateKeyException;
 
 import com.prgrms.kream.domain.coupon.dto.response.CouponEventResponse;
 import com.prgrms.kream.domain.coupon.dto.request.CouponEventServiceRequest;
+import com.prgrms.kream.domain.coupon.dto.response.CouponResponse;
 import com.prgrms.kream.domain.coupon.model.Coupon;
 import com.prgrms.kream.domain.coupon.model.CouponEvent;
 import com.prgrms.kream.domain.coupon.repository.CouponEventRepository;
@@ -37,15 +42,16 @@ class CouponEventServiceTest {
 				.name("쿠폰 이름")
 				.discountValue(50)
 				.build();
+		CouponResponse couponResponse = toCouponResponse(coupon);
 		Member member = Member.builder()
 				.id(1L)
 				.email("email")
 				.name("name")
 				.build();
-		CouponEventServiceRequest couponEventServiceRequest = new CouponEventServiceRequest(member, coupon);
+		CouponEventServiceRequest couponEventServiceRequest = new CouponEventServiceRequest(member, couponResponse);
 		CouponEvent couponEvent = CouponEvent.builder()
 				.id(1L)
-				.coupon(couponEventServiceRequest.coupon())
+				.coupon(coupon)
 				.member(couponEventServiceRequest.member())
 				.build();
 
@@ -55,6 +61,40 @@ class CouponEventServiceTest {
 
 		//then
 		assertThat(couponEventControllerResponse.id()).isEqualTo(couponEvent.getId());
+	}
+
+	@Test
+	@DisplayName("중복 발급 테스트")
+	void OverLapCouponEventTest() {
+		//given
+		Coupon coupon = Coupon.builder()
+				.id(1L)
+				.amount(100)
+				.name("쿠폰 이름")
+				.discountValue(50)
+				.build();
+		CouponResponse couponResponse = toCouponResponse(coupon);
+		Member member = Member.builder()
+				.id(1L)
+				.email("email")
+				.name("name")
+				.build();
+		CouponEventServiceRequest couponEventServiceRequest = new CouponEventServiceRequest(member, couponResponse);
+		CouponEvent couponEvent = CouponEvent.builder()
+				.id(1L)
+				.coupon(coupon)
+				.member(couponEventServiceRequest.member())
+				.build();
+
+		//when
+		when(couponEventRepository.findByMember(any(Member.class))).thenReturn(Optional.ofNullable(couponEvent));
+
+
+		//then
+		assertThatThrownBy(
+				() -> couponEventService.registerCouponEvent(couponEventServiceRequest)
+				).isInstanceOf(DuplicateKeyException.class)
+				.hasMessage("쿠폰을 중복으로 받을 수 없습니다.");
 	}
 
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 쿠폰 발급 전 쿠폰을 발급받은 내역이 있는지 확인한다.
- 테스트 코드

### 📝 작업 요약
- 쿠폰 중복 지급 방지 기능 구현


### 💡 관련 이슈
- Resolved : [SHK-40], [SHK-41]


[SHK-40]: https://shoekream.atlassian.net/browse/SHK-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-41]: https://shoekream.atlassian.net/browse/SHK-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ