### PR TITLE
[SHK-9] Member 로그인/로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,13 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
 
     //Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'com.auth0:java-jwt:4.2.2'
 

--- a/src/main/java/com/prgrms/kream/common/config/JwtConfig.java
+++ b/src/main/java/com/prgrms/kream/common/config/JwtConfig.java
@@ -1,0 +1,28 @@
+package com.prgrms.kream.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtConfig {
+	private String accessToken;
+	private String issuer;
+	private String clientSecret;
+	private int expirySeconds;
+
+	@Override
+	public String toString() {
+		return "JwtConfig{" +
+				"header='" + accessToken + '\'' +
+				", issuer='" + issuer + '\'' +
+				", clientSecret='" + clientSecret + '\'' +
+				", expirySeconds=" + expirySeconds +
+				'}';
+	}
+}

--- a/src/main/java/com/prgrms/kream/common/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/kream/common/config/SecurityConfig.java
@@ -4,10 +4,37 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.prgrms.kream.common.jwt.Jwt;
+import com.prgrms.kream.common.jwt.JwtAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtConfig jwtConfig;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public Jwt jwt() {
+		return new Jwt(jwtConfig.getIssuer(), jwtConfig.getClientSecret(), jwtConfig.getExpirySeconds());
+	}
+
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() {
+		return new JwtAuthenticationFilter(jwt(), jwtConfig.getAccessToken());
+	}
+
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
@@ -22,6 +49,8 @@ public class SecurityConfig {
 				.logout().disable()
 				.sessionManagement()
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+				.and()
+				.addFilterAfter(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
 		;
 
 		return http.build();

--- a/src/main/java/com/prgrms/kream/common/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/kream/common/jwt/Jwt.java
@@ -1,0 +1,82 @@
+package com.prgrms.kream.common.jwt;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+public class Jwt {
+
+	private final String issuer;
+	private final int expirySeconds;
+	private final Algorithm algorithm;
+	private final JWTVerifier jwtVerifier;
+
+	public Jwt(String issuer, String clientSecret, int expirySeconds) {
+		this.issuer = issuer;
+		this.expirySeconds = expirySeconds;
+		this.algorithm = Algorithm.HMAC512(clientSecret);
+		this.jwtVerifier = JWT.require(algorithm)
+				.withIssuer(issuer)
+				.build();
+	}
+
+	public String sign(Claims claims) {
+		Date now = new Date();
+		return JWT.create()
+				.withIssuer(issuer)
+				.withIssuedAt(now)
+				.withExpiresAt(new Date(now.getTime() + expirySeconds * 1000L))
+				.withClaim("memberId", claims.memberId)
+				.withArrayClaim("roles", claims.roles)
+				.sign(algorithm);
+	}
+
+	public Claims verify(String token) {
+		return new Claims(jwtVerifier.verify(token));
+	}
+
+	public static class Claims {
+		Long memberId;
+		String[] roles;
+		Date iat;
+		Date exp;
+
+		private Claims() {
+		}
+
+		Claims(DecodedJWT decodedJWT) {
+			Claim memberId = decodedJWT.getClaim("memberId");
+			if (!memberId.isNull()) {
+				this.memberId = memberId.asLong();
+			}
+			Claim roles = decodedJWT.getClaim("roles");
+			if (!roles.isNull()) {
+				this.roles = roles.asArray(String.class);
+			}
+			this.iat = decodedJWT.getIssuedAt();
+			this.exp = decodedJWT.getExpiresAt();
+		}
+
+		public static Claims from(Long memberId, String[] roles) {
+			Claims claims = new Claims();
+			claims.memberId = memberId;
+			claims.roles = roles;
+			return claims;
+		}
+
+		@Override
+		public String toString() {
+			return "Claims{" +
+					"memberId=" + memberId +
+					", roles=" + Arrays.toString(roles) +
+					", iat=" + iat +
+					", exp=" + exp +
+					'}';
+		}
+	}
+}

--- a/src/main/java/com/prgrms/kream/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/kream/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,103 @@
+package com.prgrms.kream.common.jwt;
+
+import static java.nio.charset.StandardCharsets.*;
+import static java.util.Collections.*;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+	private final Jwt jwt;
+	private final String accessToken;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+			IOException,
+			ServletException {
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)request;
+		HttpServletResponse httpServletResponse = (HttpServletResponse)response;
+
+		if (SecurityContextHolder.getContext().getAuthentication() == null) {
+			String token = getToken(httpServletRequest);
+			if (token != null) {
+				try {
+					Jwt.Claims claims = verify(token);
+					log.debug("Jwt : {}", claims);
+
+					Long memberId = claims.memberId;
+					List<GrantedAuthority> authorities = getAuthorities(claims);
+
+					if (memberId != null && memberId > 0 && authorities.size() > 0) {
+						UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+								new UsernamePasswordAuthenticationToken(memberId, null, authorities);
+						SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+					}
+				} catch (Exception e) {
+					log.warn("Jwt 처리중 문제가 발생하였습니다 : {}", e.getMessage());
+				}
+			}
+		} else {
+			log.debug("이미 인증 객체가 존재합니다 : {}",
+					SecurityContextHolder.getContext().getAuthentication());
+		}
+		chain.doFilter(httpServletRequest, httpServletResponse);
+	}
+
+	private String getToken(HttpServletRequest httpServletRequest) {
+		Cookie[] cookies = httpServletRequest.getCookies();
+		String token = null;
+		if (cookies != null) {
+			token = Arrays.stream(cookies)
+					.filter(cookie -> cookie.getName().equals(accessToken))
+					.map(Cookie::getValue)
+					.findFirst()
+					.orElse("");
+		}
+
+		if (token != null && !token.isBlank()) {
+			try {
+				return URLDecoder.decode(token, UTF_8);
+			} catch (Exception e) {
+				log.error(e.getMessage(), e);
+			}
+		}
+		return null;
+	}
+
+	private Jwt.Claims verify(String token) {
+		return jwt.verify(token);
+	}
+
+	private List<GrantedAuthority> getAuthorities(Jwt.Claims claims) {
+		String[] roles = claims.roles;
+		if (roles == null || roles.length == 0) {
+			return emptyList();
+		}
+		return Arrays.stream(roles)
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
@@ -2,10 +2,14 @@ package com.prgrms.kream.domain.member.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,7 +48,32 @@ public class MemberController {
 			@RequestBody @Valid MemberLoginRequest memberLoginRequest,
 			HttpServletResponse httpServletResponse
 	) {
-		httpServletResponse.addHeader(accessToken, memberFacade.login(memberLoginRequest).token());
+		httpServletResponse.addCookie(
+				new Cookie(accessToken, memberFacade.login(memberLoginRequest).token())
+		);
 		return ApiResponse.of("로그인 성공하였습니다.");
 	}
+
+	@GetMapping("/logout")
+	@ResponseStatus(OK)
+	public ApiResponse<String> logout(HttpServletResponse httpServletResponse) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication != null && !authentication.getPrincipal().equals("anonymousUser")) {
+			Cookie cookie = new Cookie(accessToken, "");
+			cookie.setMaxAge(0);
+			httpServletResponse.addCookie(cookie);
+		}
+
+		return ApiResponse.of("로그아웃 성공하였습니다.");
+	}
+
+	@GetMapping("/test")
+	@ResponseStatus(OK)
+	public ApiResponse<String> test() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		System.out.println(authentication);
+		return ApiResponse.of("테스트 성공하였습니다.");
+	}
+
 }

--- a/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
@@ -2,8 +2,10 @@ package com.prgrms.kream.domain.member.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.kream.common.api.ApiResponse;
+import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
 import com.prgrms.kream.domain.member.facade.MemberFacade;
@@ -24,11 +27,24 @@ public class MemberController {
 
 	private final MemberFacade memberFacade;
 
+	@Value("${jwt.accessToken}")
+	private String accessToken;
+
 	@PostMapping
 	@ResponseStatus(CREATED)
 	public ApiResponse<MemberRegisterResponse> register(
 			@RequestBody @Valid MemberRegisterRequest memberRegisterRequest
 	) {
 		return ApiResponse.of(memberFacade.register(memberRegisterRequest));
+	}
+
+	@PostMapping("/login")
+	@ResponseStatus(OK)
+	public ApiResponse<String> login(
+			@RequestBody @Valid MemberLoginRequest memberLoginRequest,
+			HttpServletResponse httpServletResponse
+	) {
+		httpServletResponse.addHeader(accessToken, memberFacade.login(memberLoginRequest).token());
+		return ApiResponse.of("로그인 성공하였습니다.");
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberLoginRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberLoginRequest.java
@@ -1,0 +1,14 @@
+package com.prgrms.kream.domain.member.dto.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+public record MemberLoginRequest(
+		@NotBlank
+		@Email
+		String email,
+
+		@NotBlank
+		String password
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberLoginResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberLoginResponse.java
@@ -1,0 +1,6 @@
+package com.prgrms.kream.domain.member.dto.response;
+
+public record MemberLoginResponse(
+		String token
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/facade/MemberFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/member/facade/MemberFacade.java
@@ -2,7 +2,9 @@ package com.prgrms.kream.domain.member.facade;
 
 import org.springframework.stereotype.Service;
 
+import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.response.MemberLoginResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
 import com.prgrms.kream.domain.member.service.MemberService;
 
@@ -17,4 +19,7 @@ public class MemberFacade {
 		return memberService.register(memberRegisterRequest);
 	}
 
+	public MemberLoginResponse login(MemberLoginRequest memberLoginRequest) {
+		return memberService.login(memberLoginRequest);
+	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/model/Member.java
+++ b/src/main/java/com/prgrms/kream/domain/member/model/Member.java
@@ -58,4 +58,17 @@ public class Member extends BaseTimeEntity {
 		this.isMale = isMale;
 		this.authority = authority;
 	}
+
+	public String getPassword() {
+		return password.getPassword();
+	}
+
+	public String getPhone() {
+		return phone.getPhone();
+	}
+
+	public boolean isNotValidPassword(String inputPassword) {
+		return !password.isValidPassword(inputPassword);
+	}
+
 }

--- a/src/main/java/com/prgrms/kream/domain/member/model/Password.java
+++ b/src/main/java/com/prgrms/kream/domain/member/model/Password.java
@@ -35,4 +35,8 @@ public class Password {
 			throw new IllegalArgumentException("비밀번호 형식을 만족하지 않습니다.");
 		}
 	}
+
+	public boolean isValidPassword(String inputPassword) {
+		return passwordEncoder.matches(inputPassword, password);
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,6 @@ logging:
   level:
     org:
       hibernate:
-        SQL: DEBUG
         type:
           descriptor:
             sql:

--- a/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
@@ -6,18 +6,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.kream.MysqlTestContainer;
+import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.model.Member;
+import com.prgrms.kream.domain.member.repository.MemberRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -28,14 +32,32 @@ class MemberControllerTest extends MysqlTestContainer {
 	private MockMvc mockMvc;
 
 	@Autowired
-	private Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder;
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@BeforeEach
+	void setUp() {
+		memberRepository.save(
+				Member.builder()
+						.email("hello@naver.com")
+						.name("name")
+						.password("Pa!12345678")
+						.phone("01012345678")
+						.isMale(true)
+						.authority(ROLE_USER)
+						.build());
+	}
+
+	@AfterEach
+	void tearDown() {
+		memberRepository.deleteAll();
+	}
 
 	@Test
-	@DisplayName("회원가입 controller test - 성공")
+	@DisplayName("회원가입 - 성공")
 	void register_success() throws Exception {
-
-		ObjectMapper objectMapper = jackson2ObjectMapperBuilder.build();
-
 		MemberRegisterRequest memberRegisterRequest = new MemberRegisterRequest(
 				"name", "email@naver.com", "01012345678", "aA12345678!", true, ROLE_USER);
 
@@ -46,5 +68,35 @@ class MemberControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.data.id").value(1L))
 				.andDo(print())
 		;
+	}
+
+	@Test
+	@DisplayName("로그인 - 성공")
+	void login_success() throws Exception {
+		MemberLoginRequest memberLoginRequest = new MemberLoginRequest(
+				"hello@naver.com", "Pa!12345678"
+		);
+
+		mockMvc.perform(post("/api/v1/member/login")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(memberLoginRequest))
+				).andExpect(status().isOk())
+				.andExpect(header().exists("access_token"))
+				.andDo(print())
+				.andReturn();
+	}
+
+	@Test
+	@DisplayName("로그인 - 실패 비밀번호 불일치")
+	void login_fail() throws Exception {
+		MemberLoginRequest memberLoginRequest = new MemberLoginRequest(
+				"hello@naver.com", "P!12345678"
+		);
+
+		mockMvc.perform(post("/api/v1/member/login")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(memberLoginRequest))
+				).andExpect(status().is4xxClientError())
+				.andDo(print());
 	}
 }

--- a/src/test/java/com/prgrms/kream/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/member/service/MemberServiceTest.java
@@ -3,14 +3,21 @@ package com.prgrms.kream.domain.member.service;
 import static com.prgrms.kream.domain.member.model.Authority.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
 
+import com.prgrms.kream.common.jwt.Jwt;
+import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.response.MemberLoginResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
 import com.prgrms.kream.domain.member.model.Member;
 import com.prgrms.kream.domain.member.repository.MemberRepository;
@@ -20,6 +27,9 @@ class MemberServiceTest {
 
 	@InjectMocks
 	private MemberService memberService;
+
+	@Mock
+	private Jwt jwt;
 
 	@Mock
 	private MemberRepository memberRepository;
@@ -38,12 +48,66 @@ class MemberServiceTest {
 				.build();
 
 		MemberRegisterRequest memberRegisterRequest = new MemberRegisterRequest(
-				"name", "email@naver.com", "01012345678", "aA12345678!", true, ROLE_USER);
+				"name", "email@naver.com", "01012345678", "aA12345678!", true, ROLE_USER
+		);
 
 		when(memberRepository.save(any(Member.class)))
 				.thenReturn(member);
 
 		MemberRegisterResponse register = memberService.register(memberRegisterRequest);
 		verify(memberRepository, times(1)).save(any(Member.class));
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 비밀번호 불일치")
+	void login_success() {
+		String password = "Pa!12345678";
+		Member member = Member.builder()
+				.id(1L)
+				.email("hello@naver.com")
+				.password(password)
+				.name("hello")
+				.phone("01012345678")
+				.authority(ROLE_USER)
+				.isMale(true)
+				.build();
+
+		when(memberRepository.findByEmail(member.getEmail()))
+				.thenReturn(Optional.of(member));
+
+		MemberLoginRequest memberLoginRequest = new MemberLoginRequest(member.getEmail(), "wrongPassword");
+		Assertions.assertThatThrownBy(() -> memberService.login(memberLoginRequest))
+				.isInstanceOf(BadCredentialsException.class);
+
+		verify(memberRepository, times(1)).findByEmail(member.getEmail());
+		verify(jwt, times(0)).sign(any(Jwt.Claims.class));
+	}
+
+	@Test
+	@DisplayName("로그인 성공")
+	void login_fail() {
+		String password = "Pa!12345678";
+		Member member = Member.builder()
+				.id(1L)
+				.email("hello@naver.com")
+				.password(password)
+				.name("hello")
+				.phone("01012345678")
+				.authority(ROLE_USER)
+				.isMale(true)
+				.build();
+
+		when(memberRepository.findByEmail(member.getEmail()))
+				.thenReturn(Optional.of(member));
+
+		String accessToken = "access_token";
+		when(jwt.sign(any(Jwt.Claims.class))).thenReturn(accessToken);
+
+		MemberLoginRequest memberLoginRequest = new MemberLoginRequest(member.getEmail(), password);
+		MemberLoginResponse login = memberService.login(memberLoginRequest);
+
+		Assertions.assertThat(login.token()).isEqualTo(accessToken);
+		verify(memberRepository, times(1)).findByEmail(member.getEmail());
+		verify(jwt, times(1)).sign(any(Jwt.Claims.class));
 	}
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- `logging.level.org.sql: Debug`  삭제
- `configuration-processor` 의존성 추가
- `JwtConfig` 구현
- `Jwt`, `JwtAuthenticationFilter` 구현
- Member jwt기반 로그인 기능 구현
- Member 로그아웃 기능 구현

### 📝 작업 요약
- 로그인 / 로그아웃 기능 구현 및 테스트

### 💡 관련 이슈
- Resolved : [SHK-149], [SHK-150], [SHK-151], [SHK-152], [SHK-153], [SHK-156], [SHK-157]


[SHK-149]: https://shoekream.atlassian.net/browse/SHK-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SHK-150]: https://shoekream.atlassian.net/browse/SHK-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-151]: https://shoekream.atlassian.net/browse/SHK-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-152]: https://shoekream.atlassian.net/browse/SHK-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-153]: https://shoekream.atlassian.net/browse/SHK-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-156]: https://shoekream.atlassian.net/browse/SHK-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-157]: https://shoekream.atlassian.net/browse/SHK-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ