### PR TITLE
[SHK-67] Feed 조회  (사용자 기준) 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
@@ -75,15 +75,11 @@ public class StyleMapper {
 	}
 
 	public static GetFeedFacadeRequest toGetFeedFacadeRequest(GetFeedRequest getFeedRequest) {
-		return new GetFeedFacadeRequest(getFeedRequest.id(), getFeedRequest.tag());
+		return new GetFeedFacadeRequest(getFeedRequest.cursorId(), getFeedRequest.pageSize());
 	}
 
 	public static GetFeedServiceRequest toGetFeedServiceRequest(GetFeedFacadeRequest getFeedFacadeRequest) {
-		return new GetFeedServiceRequest(List.of(getFeedFacadeRequest.id()));
-	}
-
-	public static GetFeedServiceRequest toGetFeedServiceRequest(List<Long> ids) {
-		return new GetFeedServiceRequest(ids);
+		return new GetFeedServiceRequest(getFeedFacadeRequest.cursorId(), getFeedFacadeRequest.pageSize());
 	}
 
 	public static GetFeedServiceResponse toGetFeedServiceResponse(Feed feed) {
@@ -97,11 +93,12 @@ public class StyleMapper {
 		);
 	}
 
-	public static GetFeedServiceResponses toGetFeedServiceResponses(List<Feed> feeds) {
+	public static GetFeedServiceResponses toGetFeedServiceResponses(List<Feed> feeds, Long lastId) {
 		return new GetFeedServiceResponses(
 				feeds.stream()
 						.map(StyleMapper::toGetFeedServiceResponse)
-						.collect(Collectors.toList())
+						.toList(),
+				lastId
 		);
 	}
 
@@ -119,8 +116,10 @@ public class StyleMapper {
 		);
 	}
 
-	public static GetFeedFacadeResponses toGetFeedFacadeResponses(List<GetFeedFacadeResponse> getFeedFacadeResponses) {
-		return new GetFeedFacadeResponses(getFeedFacadeResponses);
+	public static GetFeedFacadeResponses toGetFeedFacadeResponses(
+			List<GetFeedFacadeResponse> getFeedFacadeResponses,
+			Long lastId) {
+		return new GetFeedFacadeResponses(getFeedFacadeResponses, lastId);
 	}
 
 	public static GetFeedResponse toGetFeedResponse(GetFeedFacadeResponse getFeedFacadeResponse) {
@@ -139,7 +138,9 @@ public class StyleMapper {
 		return new GetFeedResponses(
 				getFeedFacadeResponses.getFeedFacadeResponses().stream()
 						.map(StyleMapper::toGetFeedResponse)
-						.collect(Collectors.toList()));
+						.collect(Collectors.toList()),
+				getFeedFacadeResponses.lastId()
+		);
 	}
 
 	public static UpdateFeedFacadeRequest toUpdateFeedFacadeRequest(UpdateFeedRequest updateFeedRequest) {

--- a/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
+++ b/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.kream.common.api.ApiResponse;
+import com.prgrms.kream.domain.style.dto.request.GetFeedRequest;
 import com.prgrms.kream.domain.style.dto.request.LikeFeedRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedRequest;
 import com.prgrms.kream.domain.style.dto.request.UpdateFeedRequest;
@@ -62,30 +63,38 @@ public class StyleController {
 
 	@GetMapping("/newest")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<GetFeedResponses> getNewestFeeds() {
+	public ApiResponse<GetFeedResponses> getNewestFeeds(@Valid GetFeedRequest getFeedRequest) {
 		return ApiResponse.of(
 				toGetFeedResponses(
-						styleFacade.getNewestFeeds()
+						styleFacade.getNewestFeeds(
+								toGetFeedFacadeRequest(getFeedRequest)
+						)
 				)
 		);
 	}
 
 	@GetMapping("/tags/{tag}")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<GetFeedResponses> getAllByTag(@PathVariable String tag) {
+	public ApiResponse<GetFeedResponses> getAllByTag(@PathVariable String tag, @Valid GetFeedRequest getFeedRequest) {
 		return ApiResponse.of(
 				toGetFeedResponses(
-						styleFacade.getAllByTag(tag)
+						styleFacade.getAllByTag(
+								toGetFeedFacadeRequest(getFeedRequest),
+								tag
+						)
 				)
 		);
 	}
 
 	@GetMapping("/members/{id}")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<GetFeedResponses> getAllByMember(@PathVariable Long id) {
+	public ApiResponse<GetFeedResponses> getAllByMember(@PathVariable Long id, @Valid GetFeedRequest getFeedRequest) {
 		return ApiResponse.of(
 				toGetFeedResponses(
-						styleFacade.getAllByMember(id)
+						styleFacade.getAllByMember(
+								toGetFeedFacadeRequest(getFeedRequest),
+								id
+						)
 				)
 		);
 	}

--- a/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
+++ b/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
@@ -80,6 +80,16 @@ public class StyleController {
 		);
 	}
 
+	@GetMapping("/members/{id}")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<GetFeedResponses> getAllByMember(@PathVariable Long id) {
+		return ApiResponse.of(
+				toGetFeedResponses(
+						styleFacade.getAllByMember(id)
+				)
+		);
+	}
+
 	@PutMapping("/{id}")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResponse<UpdateFeedResponse> update(
@@ -97,7 +107,7 @@ public class StyleController {
 
 	@DeleteMapping("/{id}")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<String> delete(@PathVariable long id) {
+	public ApiResponse<String> delete(@PathVariable Long id) {
 		styleFacade.delete(id);
 		return ApiResponse.of(SUCCESS_MESSAGE);
 	}
@@ -105,7 +115,7 @@ public class StyleController {
 	@PostMapping("/{id}/like")
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResponse<String> registerFeedLike(
-			@PathVariable long id,
+			@PathVariable Long id,
 			@RequestBody @Valid LikeFeedRequest likeFeedRequest) {
 		styleFacade.registerFeedLike(
 				toLikeFeedFacadeRequest(
@@ -119,7 +129,7 @@ public class StyleController {
 	@DeleteMapping("/{id}/like")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResponse<String> deleteFeedLike(
-			@PathVariable long id,
+			@PathVariable Long id,
 			@RequestBody @Valid LikeFeedRequest likeFeedRequest) {
 		styleFacade.deleteFeedLike(
 				toLikeFeedFacadeRequest(

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedFacadeRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedFacadeRequest.java
@@ -1,7 +1,7 @@
 package com.prgrms.kream.domain.style.dto.request;
 
 public record GetFeedFacadeRequest(
-		Long id,
-		String tag
+		Long cursorId,
+		Integer pageSize
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedRequest.java
@@ -1,7 +1,14 @@
 package com.prgrms.kream.domain.style.dto.request;
 
+import javax.validation.constraints.Positive;
+
 public record GetFeedRequest(
-		Long id,
-		String tag
+		Long cursorId,
+
+		@Positive(message = "pageSize는 양수여야 합니다.")
+		Integer pageSize
 ) {
+	public GetFeedRequest {
+		if (pageSize == null) pageSize = 10;
+	}
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedServiceRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedServiceRequest.java
@@ -1,8 +1,7 @@
 package com.prgrms.kream.domain.style.dto.request;
 
-import java.util.List;
-
 public record GetFeedServiceRequest(
-		List<Long> ids
+		Long cursorId,
+		Integer pageSize
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedFacadeResponses.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedFacadeResponses.java
@@ -3,6 +3,7 @@ package com.prgrms.kream.domain.style.dto.response;
 import java.util.List;
 
 public record GetFeedFacadeResponses(
-		List<GetFeedFacadeResponse> getFeedFacadeResponses
+		List<GetFeedFacadeResponse> getFeedFacadeResponses,
+		Long lastId
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedResponses.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedResponses.java
@@ -3,6 +3,7 @@ package com.prgrms.kream.domain.style.dto.response;
 import java.util.List;
 
 public record GetFeedResponses(
-		List<GetFeedResponse> getFeedResponses
+		List<GetFeedResponse> getFeedResponses,
+		Long lastId
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedServiceResponses.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedServiceResponses.java
@@ -3,6 +3,7 @@ package com.prgrms.kream.domain.style.dto.response;
 import java.util.List;
 
 public record GetFeedServiceResponses(
-		List<GetFeedServiceResponse> getFeedServiceResponses
+		List<GetFeedServiceResponse> getFeedServiceResponses,
+		Long lastId
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.prgrms.kream.domain.image.model.DomainType;
 import com.prgrms.kream.domain.image.service.ImageService;
 import com.prgrms.kream.domain.member.service.MemberService;
+import com.prgrms.kream.domain.style.dto.request.GetFeedFacadeRequest;
 import com.prgrms.kream.domain.style.dto.request.LikeFeedFacadeRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedFacadeRequest;
 import com.prgrms.kream.domain.style.dto.request.UpdateFeedFacadeRequest;
@@ -55,18 +56,18 @@ public class StyleFacade {
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedFacadeResponses getNewestFeeds() {
-		return merge(styleService.getNewestFeeds());
+	public GetFeedFacadeResponses getNewestFeeds(GetFeedFacadeRequest getFeedFacadeRequest) {
+		return merge(styleService.getNewestFeeds(toGetFeedServiceRequest(getFeedFacadeRequest)));
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedFacadeResponses getAllByTag(String tag) {
-		return merge(styleService.getAllByTag(tag));
+	public GetFeedFacadeResponses getAllByTag(GetFeedFacadeRequest getFeedFacadeRequest, String tag) {
+		return merge(styleService.getAllByTag(toGetFeedServiceRequest(getFeedFacadeRequest), tag));
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedFacadeResponses getAllByMember(Long id) {
-		return merge(styleService.getAllByMember(id));
+	public GetFeedFacadeResponses getAllByMember(GetFeedFacadeRequest getFeedFacadeRequest, Long id) {
+		return merge(styleService.getAllByMember(toGetFeedServiceRequest(getFeedFacadeRequest), id));
 	}
 
 	@Transactional
@@ -107,7 +108,9 @@ public class StyleFacade {
 										getFeedServiceResponse,
 										imageService.getAll(getFeedServiceResponse.id(), DomainType.FEED)
 								))
-						.collect(Collectors.toList()));
+						.collect(Collectors.toList()),
+				getFeedServiceResponses.lastId()
+		);
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
@@ -64,8 +64,13 @@ public class StyleFacade {
 		return merge(styleService.getAllByTag(tag));
 	}
 
+	@Transactional(readOnly = true)
+	public GetFeedFacadeResponses getAllByMember(Long id) {
+		return merge(styleService.getAllByMember(id));
+	}
+
 	@Transactional
-	public UpdateFeedFacadeResponse update(long id, UpdateFeedFacadeRequest updateFeedFacadeRequest) {
+	public UpdateFeedFacadeResponse update(Long id, UpdateFeedFacadeRequest updateFeedFacadeRequest) {
 		return toUpdateFeedFacadeResponse(
 				styleService.update(
 						id,

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
@@ -1,16 +1,17 @@
 package com.prgrms.kream.domain.style.repository;
 
+import java.awt.print.Pageable;
 import java.util.List;
 
 import com.prgrms.kream.domain.style.model.Feed;
 
 public interface FeedCustomRepository {
 
-	List<Feed> findAllByTag(String tag);
+	List<Feed> findAllByTag(String tag, Long cursorId, int pageSize);
 
-	List<Feed> findAllByMember(Long id);
+	List<Feed> findAllByMember(Long id, Long cursorId, int pageSize);
 
-	List<Feed> findAllOrderByCreatedAtDesc();
+	List<Feed> findAllOrderByCreatedAtDesc(Long cursorId, int pageSize);
 
 	List<Feed> findAllOrderByLikesDesc();
 

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
@@ -8,6 +8,8 @@ public interface FeedCustomRepository {
 
 	List<Feed> findAllByTag(String tag);
 
+	List<Feed> findAllByMember(Long id);
+
 	List<Feed> findAllOrderByCreatedAtDesc();
 
 	List<Feed> findAllOrderByLikesDesc();

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
@@ -1,6 +1,5 @@
 package com.prgrms.kream.domain.style.repository;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 import com.prgrms.kream.domain.style.model.Feed;
@@ -9,7 +8,7 @@ public interface FeedCustomRepository {
 
 	List<Feed> findAllByTag(String tag, Long cursorId, int pageSize);
 
-	List<Feed> findAllByMember(Long id, Long cursorId, int pageSize);
+	List<Feed> findAllByMember(Long memberId, Long cursorId, int pageSize);
 
 	List<Feed> findAllOrderByCreatedAtDesc(Long cursorId, int pageSize);
 

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import com.prgrms.kream.domain.style.model.Feed;
 import com.prgrms.kream.domain.style.model.QFeed;
 import com.prgrms.kream.domain.style.model.QFeedTag;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -23,32 +24,41 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
 	QFeedTag qFeedTag = QFeedTag.feedTag;
 
 	@Override
-	public List<Feed> findAllByTag(String tag) {
+	public List<Feed> findAllByTag(String tag, Long cursorId, int pageSize) {
 		return jpaQueryFactory
 				.selectFrom(qFeed)
 				.where(qFeed.id.in(
 						JPAExpressions
 								.select(qFeedTag.feedId)
 								.from(qFeedTag)
-								.where(qFeedTag.tag.eq(tag))))
+								.where(qFeedTag.tag.eq(tag))),
+						loeFeedId(cursorId)
+				)
 				.orderBy(qFeed.id.desc())
+				.limit(pageSize+1)
 				.fetch();
 	}
 
 	@Override
-	public List<Feed> findAllByMember(Long id) {
+	public List<Feed> findAllByMember(Long memberId, Long cursorId, int pageSize) {
 		return jpaQueryFactory
 				.selectFrom(qFeed)
-				.where(qFeed.authorId.eq(id))
+				.where(
+						qFeed.authorId.eq(memberId),
+						loeFeedId(cursorId)
+				)
 				.orderBy(qFeed.id.desc())
+				.limit(pageSize+1)
 				.fetch();
 	}
 
 	@Override
-	public List<Feed> findAllOrderByCreatedAtDesc() {
+	public List<Feed> findAllOrderByCreatedAtDesc(Long cursorId, int pageSize) {
 		return jpaQueryFactory
 				.selectFrom(qFeed)
+				.where(loeFeedId(cursorId))
 				.orderBy(qFeed.id.desc())
+				.limit(pageSize+1)
 				.fetch();
 	}
 
@@ -58,6 +68,10 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
 				.selectFrom(qFeed)
 				.orderBy(qFeed.likes.desc(), qFeed.createdAt.desc())
 				.fetch();
+	}
+
+	private BooleanExpression loeFeedId(Long feedId) {
+		return (feedId == null) ? null : qFeed.id.loe(feedId);
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepositoryImpl.java
@@ -36,6 +36,15 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
 	}
 
 	@Override
+	public List<Feed> findAllByMember(Long id) {
+		return jpaQueryFactory
+				.selectFrom(qFeed)
+				.where(qFeed.authorId.eq(id))
+				.orderBy(qFeed.id.desc())
+				.fetch();
+	}
+
+	@Override
 	public List<Feed> findAllOrderByCreatedAtDesc() {
 		return jpaQueryFactory
 				.selectFrom(qFeed)

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedLikeRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedLikeRepository.java
@@ -1,15 +1,17 @@
 package com.prgrms.kream.domain.style.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.prgrms.kream.domain.style.model.FeedLike;
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
 
-	long countByFeedId(Long feedId);
-
 	boolean existsByFeedIdAndMemberId(Long feedId, Long memberId);
 
+	@Modifying
+	@Query("delete from FeedLike feedlike where feedlike.feedId = :feedId")
 	void deleteAllByFeedId(Long feedId);
 
 	void deleteByFeedIdAndMemberId(Long feedId, Long memberId);

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedTagRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedTagRepository.java
@@ -1,15 +1,15 @@
 package com.prgrms.kream.domain.style.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.prgrms.kream.domain.style.model.FeedTag;
 
 public interface FeedTagRepository extends JpaRepository<FeedTag, Long> {
 
-	List<FeedTag> findAllByTag(String tag);
-
+	@Modifying
+	@Query("delete from FeedTag feedTag where feedTag.feedId = :feedId")
 	void deleteAllByFeedId(Long feedId);
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -61,8 +61,13 @@ public class StyleService {
 		return toGetFeedServiceResponses(feedRepository.findAllByTag(tag));
 	}
 
+	@Transactional(readOnly = true)
+	public GetFeedServiceResponses getAllByMember(Long id) {
+		return toGetFeedServiceResponses(feedRepository.findAllByMember(id));
+	}
+
 	@Transactional
-	public UpdateFeedServiceResponse update(long id, UpdateFeedServiceRequest updateFeedServiceRequest) {
+	public UpdateFeedServiceResponse update(Long id, UpdateFeedServiceRequest updateFeedServiceRequest) {
 		Feed updatedFeed = feedRepository.findById(id)
 				.map(feed -> {
 					feed.updateContent(updateFeedServiceRequest.content());
@@ -81,7 +86,7 @@ public class StyleService {
 	}
 
 	@Transactional
-	public void delete(long id) {
+	public void delete(Long id) {
 		feedRepository.findById(id)
 				.ifPresent(feed -> {
 					// 관련 테이블의 레코드 삭제 (Cascade)

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -2,6 +2,7 @@ package com.prgrms.kream.domain.style.service;
 
 import static com.prgrms.kream.common.mapper.StyleMapper.*;
 
+import java.util.List;
 import java.util.Set;
 
 import javax.persistence.EntityNotFoundException;
@@ -9,6 +10,7 @@ import javax.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.kream.domain.style.dto.request.GetFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.LikeFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.UpdateFeedServiceRequest;
@@ -48,22 +50,63 @@ public class StyleService {
 
 	@Transactional(readOnly = true)
 	public GetFeedServiceResponses getTrendingFeeds() {
-		return toGetFeedServiceResponses(feedRepository.findAllOrderByLikesDesc());
+		return toGetFeedServiceResponses(
+				feedRepository.findAllOrderByLikesDesc(),
+				-1L
+		);
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedServiceResponses getNewestFeeds() {
-		return toGetFeedServiceResponses(feedRepository.findAllOrderByCreatedAtDesc());
+	public GetFeedServiceResponses getNewestFeeds(GetFeedServiceRequest getFeedServiceRequest) {
+		List<Feed> feeds = feedRepository.findAllOrderByCreatedAtDesc(
+				getFeedServiceRequest.cursorId(),
+				getFeedServiceRequest.pageSize()
+		);
+
+		if (feeds.size() > getFeedServiceRequest.pageSize()) {
+			return toGetFeedServiceResponses(
+					feeds.subList(0, feeds.size()-1),
+					feeds.get(feeds.size()-1).getId()
+			);
+		}
+
+		return toGetFeedServiceResponses(feeds, -1L);
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedServiceResponses getAllByTag(String tag) {
-		return toGetFeedServiceResponses(feedRepository.findAllByTag(tag));
+	public GetFeedServiceResponses getAllByTag(GetFeedServiceRequest getFeedServiceRequest, String tag) {
+		List<Feed> feeds = feedRepository.findAllByTag(
+				tag,
+				getFeedServiceRequest.cursorId(),
+				getFeedServiceRequest.pageSize()
+		);
+
+		if (feeds.size() > getFeedServiceRequest.pageSize()) {
+			return toGetFeedServiceResponses(
+					feeds.subList(0, feeds.size()-1),
+					feeds.get(feeds.size()-1).getId()
+			);
+		}
+
+		return toGetFeedServiceResponses(feeds, -1L);
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedServiceResponses getAllByMember(Long id) {
-		return toGetFeedServiceResponses(feedRepository.findAllByMember(id));
+	public GetFeedServiceResponses getAllByMember(GetFeedServiceRequest getFeedServiceRequest, Long id) {
+		List<Feed> feeds = feedRepository.findAllByMember(
+				id,
+				getFeedServiceRequest.cursorId(),
+				getFeedServiceRequest.pageSize()
+		);
+
+		if (feeds.size() > getFeedServiceRequest.pageSize()) {
+			return toGetFeedServiceResponses(
+					feeds.subList(0, feeds.size()-1),
+					feeds.get(feeds.size()-1).getId()
+			);
+		}
+
+		return toGetFeedServiceResponses(feeds, -1L);
 	}
 
 	@Transactional

--- a/src/test/java/com/prgrms/kream/domain/style/controller/StyleControllerTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/controller/StyleControllerTest.java
@@ -139,4 +139,13 @@ class StyleControllerTest extends MysqlTestContainer {
 				.andDo(print());
 	}
 
+	@Test
+	@Order(8)
+	@DisplayName("사용자 기준으로 피드를 조회할 수 있다.")
+	void testGetFeedsByMember() throws Exception {
+		mockMvc.perform(get("/api/v1/feed/members/" + memberId))
+				.andExpect(status().isOk())
+				.andDo(print());
+	}
+
 }

--- a/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
@@ -144,6 +144,16 @@ class StyleServiceTest {
 		assertThat(getFeedServiceResponses.getFeedServiceResponses()).isNotEmpty();
 	}
 
+	@Test
+	@DisplayName("사용자 식별자를 기준으로 피드를 조회할 수 있다.")
+	void testGetFeedsByMember() {
+		when(feedRepository.findAllByMember(MEMBER.getId())).thenReturn(List.of(FEED));
+
+		GetFeedServiceResponses getFeedServiceResponses = styleService.getAllByMember(MEMBER.getId());
+
+		assertThat(getFeedServiceResponses.getFeedServiceResponses()).isNotEmpty();
+	}
+
 	private RegisterFeedServiceRequest getRegisterFeedServiceRequest() {
 		return new RegisterFeedServiceRequest(FEED.getContent(), MEMBER.getId());
 	}

--- a/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.prgrms.kream.domain.member.model.Authority;
 import com.prgrms.kream.domain.member.model.Member;
+import com.prgrms.kream.domain.style.dto.request.GetFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.LikeFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.RegisterFeedServiceRequest;
 import com.prgrms.kream.domain.style.dto.request.UpdateFeedServiceRequest;
@@ -137,9 +138,15 @@ class StyleServiceTest {
 	@Test
 	@DisplayName("태그 기준으로 피드 식별자를 조회할 수 있다.")
 	void testGetFeedsByTag() {
-		when(feedRepository.findAllByTag(FEED_TAGS.stream().findAny().get().getTag())).thenReturn(List.of(FEED));
+		when(feedRepository.findAllByTag(
+				FEED_TAGS.stream().findAny().get().getTag(),
+				getFeedServiceRequest().cursorId(),
+				getFeedServiceRequest().pageSize()
+		)).thenReturn(List.of(FEED));
 
-		GetFeedServiceResponses getFeedServiceResponses = styleService.getAllByTag(FEED_TAGS.stream().toList().get(0).getTag());
+		GetFeedServiceResponses getFeedServiceResponses = styleService.getAllByTag(
+				getFeedServiceRequest(),
+				FEED_TAGS.stream().toList().get(0).getTag());
 
 		assertThat(getFeedServiceResponses.getFeedServiceResponses()).isNotEmpty();
 	}
@@ -147,15 +154,25 @@ class StyleServiceTest {
 	@Test
 	@DisplayName("사용자 식별자를 기준으로 피드를 조회할 수 있다.")
 	void testGetFeedsByMember() {
-		when(feedRepository.findAllByMember(MEMBER.getId())).thenReturn(List.of(FEED));
+		when(feedRepository.findAllByMember(
+				MEMBER.getId(),
+				getFeedServiceRequest().cursorId(),
+				getFeedServiceRequest().pageSize()
+		)).thenReturn(List.of(FEED));
 
-		GetFeedServiceResponses getFeedServiceResponses = styleService.getAllByMember(MEMBER.getId());
+		GetFeedServiceResponses getFeedServiceResponses = styleService.getAllByMember(
+				getFeedServiceRequest(),
+				MEMBER.getId());
 
 		assertThat(getFeedServiceResponses.getFeedServiceResponses()).isNotEmpty();
 	}
 
 	private RegisterFeedServiceRequest getRegisterFeedServiceRequest() {
 		return new RegisterFeedServiceRequest(FEED.getContent(), MEMBER.getId());
+	}
+
+	private GetFeedServiceRequest getFeedServiceRequest() {
+		return new GetFeedServiceRequest(FEED.getId(), 10);
 	}
 
 	private UpdateFeedServiceRequest getUpdateFeedServiceRequest(String content) {


### PR DESCRIPTION
### ⛏ 작업 사항
- 피드 사용자 기준 조회 API 구현
- 관련 단위 및 통합 테스트 코드 작성
- 피드 삭제 시 관련 테이블 삭제 쿼리 N+1 이슈 해결

### 📝 작업 요약
- 피드 사용자 기준 조회 기능 구현 및 삭제 쿼리 안정화

### 💡 관련 이슈
- Resolved : [SHK-165]


[SHK-165]: https://shoekream.atlassian.net/browse/SHK-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ