### PR TITLE
[SHK-10] Member 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/kream/common/jwt/JwtUtil.java
+++ b/src/main/java/com/prgrms/kream/common/jwt/JwtUtil.java
@@ -1,0 +1,18 @@
+package com.prgrms.kream.common.jwt;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JwtUtil {
+	public static Long getMemberId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+			throw new AccessDeniedException("잘못된 접근입니다.");
+		}
+		return (Long)authentication.getPrincipal();
+	}
+}

--- a/src/main/java/com/prgrms/kream/common/mapper/MemberMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/MemberMapper.java
@@ -2,7 +2,11 @@ package com.prgrms.kream.common.mapper;
 
 import static lombok.AccessLevel.*;
 
+import java.util.List;
+
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.response.MemberGetFacadeResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberGetResponse;
 import com.prgrms.kream.domain.member.model.Member;
 
 import lombok.NoArgsConstructor;
@@ -18,6 +22,44 @@ public class MemberMapper {
 				.password(memberRegisterRequest.password())
 				.authority(memberRegisterRequest.authority())
 				.isMale(memberRegisterRequest.isMale())
+				.build();
+	}
+
+	public static Member toMember(MemberGetFacadeResponse memberGetFacadeResponse) {
+		return Member.builder()
+				.id(memberGetFacadeResponse.id())
+				.name(memberGetFacadeResponse.name())
+				.email(memberGetFacadeResponse.email())
+				.phone(memberGetFacadeResponse.phone())
+				.password(memberGetFacadeResponse.password())
+				.authority(memberGetFacadeResponse.authority())
+				.build();
+	}
+
+	public static MemberGetFacadeResponse toMemberGetFacadeResponse(Member member) {
+		return MemberGetFacadeResponse.builder()
+				.id(member.getId())
+				.name(member.getName())
+				.email(member.getEmail())
+				.phone(member.getPhone())
+				.password(member.getPassword())
+				.isMale(member.getIsMale())
+				.authority(member.getAuthority())
+				.build();
+	}
+
+	public static MemberGetResponse toMemberGetResponse(
+			MemberGetFacadeResponse memberGetFacadeResponse,
+			List<String> imagePaths
+	) {
+		return MemberGetResponse.builder()
+				.id(memberGetFacadeResponse.id())
+				.name(memberGetFacadeResponse.name())
+				.email(memberGetFacadeResponse.email())
+				.phone(memberGetFacadeResponse.phone())
+				.isMale(memberGetFacadeResponse.isMale())
+				.authority(memberGetFacadeResponse.authority())
+				.imagePaths(imagePaths)
 				.build();
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
 	@Value("${jwt.accessToken}")
 	private String accessToken;
 
-	@PostMapping
+	@PostMapping("/signup")
 	@ResponseStatus(CREATED)
 	public ApiResponse<MemberRegisterResponse> register(
 			@RequestBody @Valid MemberRegisterRequest memberRegisterRequest

--- a/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.prgrms.kream.common.api.ApiResponse;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.response.MemberGetResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
 import com.prgrms.kream.domain.member.facade.MemberFacade;
 
@@ -66,5 +68,11 @@ public class MemberController {
 		}
 
 		return ApiResponse.of("로그아웃 성공하였습니다.");
+	}
+
+	@GetMapping("/{id}")
+	@ResponseStatus(OK)
+	public ApiResponse<MemberGetResponse> get(@PathVariable Long id) {
+		return ApiResponse.of(memberFacade.get(id));
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberGetFacadeResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberGetFacadeResponse.java
@@ -1,0 +1,17 @@
+package com.prgrms.kream.domain.member.dto.response;
+
+import com.prgrms.kream.domain.member.model.Authority;
+
+import lombok.Builder;
+
+@Builder
+public record MemberGetFacadeResponse(
+		Long id,
+		String name,
+		String email,
+		String phone,
+		String password,
+		Boolean isMale,
+		Authority authority
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberGetResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberGetResponse.java
@@ -1,0 +1,19 @@
+package com.prgrms.kream.domain.member.dto.response;
+
+import java.util.List;
+
+import com.prgrms.kream.domain.member.model.Authority;
+
+import lombok.Builder;
+
+@Builder
+public record MemberGetResponse(
+		Long id,
+		String name,
+		String email,
+		String phone,
+		Boolean isMale,
+		Authority authority,
+		List<String> imagePaths
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/facade/MemberFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/member/facade/MemberFacade.java
@@ -1,9 +1,18 @@
 package com.prgrms.kream.domain.member.facade;
 
-import org.springframework.stereotype.Service;
+import static com.prgrms.kream.common.mapper.MemberMapper.*;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.kream.domain.image.model.DomainType;
+import com.prgrms.kream.domain.image.service.ImageService;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.response.MemberGetFacadeResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberGetResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberLoginResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
 import com.prgrms.kream.domain.member.service.MemberService;
@@ -14,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberFacade {
 	private final MemberService memberService;
+	private final ImageService imageService;
 
 	public MemberRegisterResponse register(MemberRegisterRequest memberRegisterRequest) {
 		return memberService.register(memberRegisterRequest);
@@ -21,5 +31,12 @@ public class MemberFacade {
 
 	public MemberLoginResponse login(MemberLoginRequest memberLoginRequest) {
 		return memberService.login(memberLoginRequest);
+	}
+
+	@Transactional(readOnly = true)
+	public MemberGetResponse get(Long memberId) {
+		MemberGetFacadeResponse memberGetFacadeResponse = memberService.get(memberId);
+		List<String> imagePaths = imageService.getAll(memberId, DomainType.MEMBER);
+		return toMemberGetResponse(memberGetFacadeResponse, imagePaths);
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/kream/domain/member/service/MemberService.java
@@ -1,16 +1,23 @@
 package com.prgrms.kream.domain.member.service;
 
+import static com.prgrms.kream.common.mapper.MemberMapper.*;
+
+import java.util.Objects;
+
 import javax.persistence.EntityNotFoundException;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.kream.common.exception.DuplicatedEmailException;
 import com.prgrms.kream.common.jwt.Jwt;
+import com.prgrms.kream.common.jwt.JwtUtil;
 import com.prgrms.kream.common.mapper.MemberMapper;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.response.MemberGetFacadeResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberLoginResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
 import com.prgrms.kream.domain.member.model.Member;
@@ -52,5 +59,16 @@ public class MemberService {
 
 	private boolean isDuplicatedEmail(String email) {
 		return memberRepository.existsMemberByEmail(email);
+	}
+
+	@Transactional(readOnly = true)
+	public MemberGetFacadeResponse get(Long id) {
+		if (!Objects.equals(JwtUtil.getMemberId(), id)) {
+			throw new AccessDeniedException("잘못된 접근입니다");
+		}
+
+		Member member = memberRepository.findById(id)
+				.orElseThrow(() -> new EntityNotFoundException("존재하지 않은 회원입니다."));
+		return toMemberGetFacadeResponse(member);
 	}
 }

--- a/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
@@ -107,11 +107,11 @@ class MemberControllerTest extends MysqlTestContainer {
 		MemberRegisterRequest memberRegisterRequest = new MemberRegisterRequest(
 				"name", "email@naver.com", "01012345678", "aA12345678!", true, ROLE_USER);
 
-		mockMvc.perform(post("/api/v1/member")
+		mockMvc.perform(post("/api/v1/member/signup")
 						.contentType(APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(memberRegisterRequest))
 				).andExpect(status().isCreated())
-				.andExpect(jsonPath("$.data.id").value(1L))
+				.andExpect(jsonPath("$.data.id").value(Matchers.any(Number.class)))
 				.andDo(print())
 		;
 	}

--- a/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
@@ -1,10 +1,13 @@
 package com.prgrms.kream.domain.member.controller;
 
+import static com.prgrms.kream.domain.image.model.DomainType.*;
 import static com.prgrms.kream.domain.member.model.Authority.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
 
 import javax.servlet.http.Cookie;
 
@@ -17,12 +20,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.kream.MysqlTestContainer;
+import com.prgrms.kream.domain.image.model.Image;
+import com.prgrms.kream.domain.image.repository.ImageRepository;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
 import com.prgrms.kream.domain.member.model.Member;
@@ -45,6 +54,9 @@ class MemberControllerTest extends MysqlTestContainer {
 	@Autowired
 	private MemberRepository memberRepository;
 
+	@Autowired
+	private ImageRepository imageRepository;
+
 	@BeforeEach
 	void setUp() {
 		memberRepository.save(
@@ -56,6 +68,32 @@ class MemberControllerTest extends MysqlTestContainer {
 						.isMale(true)
 						.authority(ROLE_USER)
 						.build());
+
+		imageRepository.save(
+				Image.builder()
+						.referenceId(1L)
+						.domainType(MEMBER)
+						.fullPath("/path/test1")
+						.originalName("profile1")
+						.build()
+		);
+
+		imageRepository.save(
+				Image.builder()
+						.referenceId(1L)
+						.domainType(MEMBER)
+						.fullPath("/path/test2")
+						.originalName("profile2")
+						.build()
+		);
+
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(
+						1L, null, List.of(new SimpleGrantedAuthority(ROLE_USER.name()))
+				);
+
+		context.setAuthentication(usernamePasswordAuthenticationToken);
 	}
 
 	@AfterEach
@@ -112,6 +150,22 @@ class MemberControllerTest extends MysqlTestContainer {
 		mockMvc.perform(get("/api/v1/member/logout").cookie(tokenCookie))
 				.andExpect(status().isOk())
 				.andExpect(header().string("Set-Cookie", Matchers.startsWith(accessToken + "=; Max-Age=0;")))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("사용자 정보 조회 성공")
+	void get_success() throws Exception {
+		mockMvc.perform(get("/api/v1/member/1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.id").value(1))
+				.andExpect(jsonPath("$.data.name").value("name"))
+				.andExpect(jsonPath("$.data.email").value("hello@naver.com"))
+				.andExpect(jsonPath("$.data.phone").value("01012345678"))
+				.andExpect(jsonPath("$.data.isMale").value(true))
+				.andExpect(jsonPath("$.data.authority").value(ROLE_USER.name()))
+				.andExpect(jsonPath("$.data.imagePaths[0]").value("/path/test1"))
+				.andExpect(jsonPath("$.data.imagePaths[1]").value("/path/test2"))
 				.andDo(print());
 	}
 }

--- a/src/test/java/com/prgrms/kream/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/member/service/MemberServiceTest.java
@@ -3,20 +3,30 @@ package com.prgrms.kream.domain.member.service;
 import static com.prgrms.kream.domain.member.model.Authority.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.EntityNotFoundException;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.prgrms.kream.common.jwt.Jwt;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.response.MemberGetFacadeResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberLoginResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
 import com.prgrms.kream.domain.member.model.Member;
@@ -33,6 +43,17 @@ class MemberServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
+
+	@BeforeEach
+	void setUp() {
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(
+						1L, null, List.of(new SimpleGrantedAuthority(ROLE_USER.name()))
+				);
+
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
 
 	@Test
 	@DisplayName("회원가입 - 성공")
@@ -54,7 +75,13 @@ class MemberServiceTest {
 		when(memberRepository.save(any(Member.class)))
 				.thenReturn(member);
 
-		MemberRegisterResponse register = memberService.register(memberRegisterRequest);
+		MemberRegisterResponse memberRegisterResponse = memberService.register(memberRegisterRequest);
+
+		// 테스트 추가
+		Assertions.assertThat(memberRegisterResponse)
+				.usingRecursiveComparison()
+				.isEqualTo(member);
+
 		verify(memberRepository, times(1)).save(any(Member.class));
 	}
 
@@ -109,5 +136,53 @@ class MemberServiceTest {
 		Assertions.assertThat(login.token()).isEqualTo(accessToken);
 		verify(memberRepository, times(1)).findByEmail(member.getEmail());
 		verify(jwt, times(1)).sign(any(Jwt.Claims.class));
+	}
+
+	@Test
+	@DisplayName("회원 정보 조회 성공")
+	void get_success() {
+		String password = "Pa!12345678";
+		Member member = Member.builder()
+				.id(1L)
+				.email("hello@naver.com")
+				.password(password)
+				.name("hello")
+				.phone("01012345678")
+				.authority(ROLE_USER)
+				.isMale(true)
+				.build();
+
+		when(memberRepository.findById(1L))
+				.thenReturn(Optional.of(member));
+
+		MemberGetFacadeResponse memberGetFacadeResponse = memberService.get(member.getId());
+
+		Assertions.assertThat(memberGetFacadeResponse)
+				.usingRecursiveComparison()
+				.isEqualTo(member);
+
+		verify(memberRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	@DisplayName("회원 정보 조회 실패 - id에 해당하는 member 존재하지 않음")
+	void get_fail_notExistMember() {
+		when(memberRepository.findById(1L))
+				.thenReturn(Optional.empty());
+
+		Assertions.assertThatThrownBy(() -> memberService.get(1L))
+				.isInstanceOf(EntityNotFoundException.class)
+				.hasMessage("존재하지 않은 회원입니다.");
+
+		verify(memberRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	@DisplayName("회원 정보 조회 실패 - 사용자가 다른 사용자의 정보 조회")
+	void get_fail_otherMember() {
+		Assertions.assertThatThrownBy(() -> memberService.get(2L))
+				.isInstanceOf(AccessDeniedException.class);
+
+		verify(memberRepository, times(0)).findById(2L);
 	}
 }

--- a/src/test/java/com/prgrms/kream/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/member/service/MemberServiceTest.java
@@ -56,7 +56,7 @@ class MemberServiceTest {
 	}
 
 	@Test
-	@DisplayName("회원가입 - 성공")
+	@DisplayName("회원가입 성공")
 	void register_success() {
 		Member member = Member.builder()
 				.id(1L)
@@ -86,8 +86,8 @@ class MemberServiceTest {
 	}
 
 	@Test
-	@DisplayName("로그인 실패 - 비밀번호 불일치")
-	void login_success() {
+	@DisplayName("로그인 실패 - 비밀번호 불일치함")
+	void login_fail_password() {
 		String password = "Pa!12345678";
 		Member member = Member.builder()
 				.id(1L)
@@ -107,6 +107,17 @@ class MemberServiceTest {
 				.isInstanceOf(BadCredentialsException.class);
 
 		verify(memberRepository, times(1)).findByEmail(member.getEmail());
+		verify(jwt, times(0)).sign(any(Jwt.Claims.class));
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 존재하지 않는 이메일")
+	void login_fail_notExistEmail() {
+		MemberLoginRequest memberLoginRequest = new MemberLoginRequest("wrongEmail", "Pa!12345678");
+		Assertions.assertThatThrownBy(() -> memberService.login(memberLoginRequest))
+				.isInstanceOf(EntityNotFoundException.class);
+
+		verify(memberRepository, times(1)).findByEmail("wrongEmail");
 		verify(jwt, times(0)).sign(any(Jwt.Claims.class));
 	}
 


### PR DESCRIPTION
### ⛏ 작업 사항
- `JwtUtil` 구현
- 사용자 정보 조회 기능 구현
- `MemberControllerTest` 수정
- `MemberServiceTest` 수정

### 📝 작업 요약
- 사용자 정보 조회 기능 구현 및 테스트 추가
- 테스트 수정

### 💡 관련 이슈
- Resolved : [SHK-195], [SHK-196], [SHK-197]


[SHK-195]: https://shoekream.atlassian.net/browse/SHK-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-196]: https://shoekream.atlassian.net/browse/SHK-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-197]: https://shoekream.atlassian.net/browse/SHK-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ