### PR TITLE
[SHK-203] Image 삭제 기능 수정

### DIFF
--- a/src/main/java/com/prgrms/kream/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/image/repository/ImageRepository.java
@@ -10,5 +10,5 @@ import com.prgrms.kream.domain.image.model.Image;
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findAllByReferenceIdAndDomainType(Long referenceId, DomainType domainType);
 
-	void deleteAllByReferenceId(Long referenceId);
+	void deleteAllByReferenceIdAndDomainType(Long referenceId, DomainType domainType);
 }

--- a/src/main/java/com/prgrms/kream/domain/image/service/ImageLocalService.java
+++ b/src/main/java/com/prgrms/kream/domain/image/service/ImageLocalService.java
@@ -46,8 +46,8 @@ public class ImageLocalService implements ImageService {
 	}
 
 	@Override
-	public void deleteAllByProduct(Long productId) {
-		imageRepository.deleteAllByReferenceId(productId);
+	public void deleteAllByReference(Long referenceId, DomainType domainType) {
+		imageRepository.deleteAllByReferenceIdAndDomainType(referenceId, domainType);
 	}
 
 	private List<Image> uploadImages(List<MultipartFile> multipartFiles, Long referenceId, DomainType domainType) {

--- a/src/main/java/com/prgrms/kream/domain/image/service/ImageS3Service.java
+++ b/src/main/java/com/prgrms/kream/domain/image/service/ImageS3Service.java
@@ -47,8 +47,8 @@ public class ImageS3Service implements ImageService {
 	}
 
 	@Override
-	public void deleteAllByProduct(Long productId) {
-		imageRepository.deleteAllByReferenceId(productId);
+	public void deleteAllByReference(Long referenceId, DomainType domainType) {
+		imageRepository.deleteAllByReferenceIdAndDomainType(referenceId, domainType);
 	}
 
 	private List<Image> uploadImages(List<MultipartFile> multipartFiles, Long referenceId, DomainType domainType) {

--- a/src/main/java/com/prgrms/kream/domain/image/service/ImageService.java
+++ b/src/main/java/com/prgrms/kream/domain/image/service/ImageService.java
@@ -12,5 +12,5 @@ public interface ImageService {
 
 	List<String> getAll(Long referenceId, DomainType domainType);
 
-	void deleteAllByProduct(Long productId);
+	void deleteAllByReference(Long referenceId, DomainType domainType);
 }

--- a/src/main/java/com/prgrms/kream/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/product/facade/ProductFacade.java
@@ -53,7 +53,7 @@ public class ProductFacade {
 
 	@Transactional
 	public void delete(Long id) {
-		imageService.deleteAllByProduct(id);
+		imageService.deleteAllByReference(id, DomainType.PRODUCT);
 		productService.delete(id);
 	}
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 메서드명 deleteAllByProduct-> deleteAllByReference로 수정
- 도메인타입 아이디 뿐 아니라, 어떤 도메인타입인지도 비교해서 삭제하는 것으로 수정

### 📝 작업 요약
- Fix : 이미지 삭제 기능, 도메인타입도 반영해서 수정

### 💡 관련 이슈
- Resolved : [SHK-204], [SHK-205]


[SHK-204]: https://shoekream.atlassian.net/browse/SHK-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-205]: https://shoekream.atlassian.net/browse/SHK-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ