### PR TITLE
[SHK-64] FeedProduct 등록, 조회 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
@@ -64,7 +64,7 @@ public class StyleMapper {
 				.build();
 	}
 
-	public static List<FeedProduct> toFeedProduct(Long feedId, List<Long> productIds) {
+	public static List<FeedProduct> toFeedProducts(Long feedId, List<Long> productIds) {
 		return productIds.stream()
 				.map(productId -> FeedProduct.builder()
 						.feedId(feedId)

--- a/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
@@ -29,6 +29,7 @@ import com.prgrms.kream.domain.style.dto.response.UpdateFeedResponse;
 import com.prgrms.kream.domain.style.dto.response.UpdateFeedServiceResponse;
 import com.prgrms.kream.domain.style.model.Feed;
 import com.prgrms.kream.domain.style.model.FeedLike;
+import com.prgrms.kream.domain.style.model.FeedProduct;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -41,7 +42,8 @@ public class StyleMapper {
 		return new RegisterFeedFacadeRequest(
 				registerFeedRequest.content(),
 				registerFeedRequest.authorId(),
-				registerFeedRequest.images()
+				registerFeedRequest.images(),
+				registerFeedRequest.productIds()
 		);
 	}
 
@@ -49,7 +51,8 @@ public class StyleMapper {
 			RegisterFeedFacadeRequest registerFeedFacadeRequest) {
 		return new RegisterFeedServiceRequest(
 				registerFeedFacadeRequest.content(),
-				registerFeedFacadeRequest.authorId()
+				registerFeedFacadeRequest.authorId(),
+				registerFeedFacadeRequest.productIds()
 		);
 	}
 
@@ -59,6 +62,15 @@ public class StyleMapper {
 				.authorId(registerFeedServiceRequest.authorId())
 				.likes(0L)
 				.build();
+	}
+
+	public static List<FeedProduct> toFeedProduct(Long feedId, List<Long> productIds) {
+		return productIds.stream()
+				.map(productId -> FeedProduct.builder()
+						.feedId(feedId)
+						.productId(productId)
+						.build())
+				.toList();
 	}
 
 	public static RegisterFeedServiceResponse toRegisterFeedServiceResponse(Feed feed) {

--- a/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
@@ -100,6 +100,7 @@ public class StyleMapper {
 				feed.getAuthorId(),
 				feed.getContent(),
 				feed.getLikes(),
+				feed.getProductIds(),
 				feed.getCreatedAt(),
 				feed.getUpdatedAt()
 		);
@@ -122,6 +123,7 @@ public class StyleMapper {
 				getFeedServiceResponse.authorId(),
 				getFeedServiceResponse.content(),
 				getFeedServiceResponse.likes(),
+				getFeedServiceResponse.products(),
 				images,
 				getFeedServiceResponse.createdAt(),
 				getFeedServiceResponse.updatedAt()
@@ -140,6 +142,7 @@ public class StyleMapper {
 				getFeedFacadeResponse.authorId(),
 				getFeedFacadeResponse.content(),
 				getFeedFacadeResponse.likes(),
+				getFeedFacadeResponse.products(),
 				getFeedFacadeResponse.images(),
 				getFeedFacadeResponse.createdAt(),
 				getFeedFacadeResponse.updatedAt()

--- a/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
+++ b/src/main/java/com/prgrms/kream/domain/style/controller/StyleController.java
@@ -53,10 +53,12 @@ public class StyleController {
 
 	@GetMapping("/trending")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<GetFeedResponses> getTrendingFeeds() {
+	public ApiResponse<GetFeedResponses> getTrendingFeeds(@Valid GetFeedRequest getFeedRequest) {
 		return ApiResponse.of(
 				toGetFeedResponses(
-						styleFacade.getTrendingFeeds()
+						styleFacade.getTrendingFeeds(
+								toGetFeedFacadeRequest(getFeedRequest)
+						)
 				)
 		);
 	}

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/GetFeedRequest.java
@@ -9,6 +9,6 @@ public record GetFeedRequest(
 		Integer pageSize
 ) {
 	public GetFeedRequest {
-		if (pageSize == null) pageSize = 10;
+		if (pageSize == null || pageSize < 0) pageSize = 10;
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedFacadeRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedFacadeRequest.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 public record RegisterFeedFacadeRequest(
 		String content,
 		Long authorId,
-		List<MultipartFile> images
+		List<MultipartFile> images,
+		List<Long> productIds
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedRequest.java
@@ -11,9 +11,13 @@ import org.springframework.web.multipart.MultipartFile;
 public record RegisterFeedRequest(
 		@NotEmpty(message = "피드 본문이 비어있을 수 없습니다.")
 		String content,
+
 		@NotNull(message = "작성자 식별값은 비어있을 수 없습니다.")
 		@Positive(message = "작성자 식별값이 올바르지 않습니다.")
 		Long authorId,
-		List<MultipartFile> images
+
+		List<MultipartFile> images,
+
+		List<Long> productIds
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedServiceRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/RegisterFeedServiceRequest.java
@@ -1,7 +1,10 @@
 package com.prgrms.kream.domain.style.dto.request;
 
+import java.util.List;
+
 public record RegisterFeedServiceRequest(
 		String content,
-		Long authorId
+		Long authorId,
+		List<Long> productsIds
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedFacadeResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedFacadeResponse.java
@@ -8,6 +8,7 @@ public record GetFeedFacadeResponse(
 		Long authorId,
 		String content,
 		Long likes,
+		List<Long> products,
 		List<String> images,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt

--- a/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedResponse.java
@@ -8,6 +8,7 @@ public record GetFeedResponse(
 		Long authorId,
 		String content,
 		Long likes,
+		List<Long> products,
 		List<String> images,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt

--- a/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedServiceResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/response/GetFeedServiceResponse.java
@@ -1,12 +1,14 @@
 package com.prgrms.kream.domain.style.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record GetFeedServiceResponse(
 		Long id,
 		Long authorId,
 		String content,
 		Long likes,
+		List<Long> products,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/style/facade/StyleFacade.java
@@ -51,8 +51,8 @@ public class StyleFacade {
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedFacadeResponses getTrendingFeeds() {
-		return merge(styleService.getTrendingFeeds());
+	public GetFeedFacadeResponses getTrendingFeeds(GetFeedFacadeRequest getFeedFacadeRequest) {
+		return merge(styleService.getTrendingFeeds(toGetFeedServiceRequest(getFeedFacadeRequest)));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/prgrms/kream/domain/style/model/Feed.java
+++ b/src/main/java/com/prgrms/kream/domain/style/model/Feed.java
@@ -1,11 +1,15 @@
 package com.prgrms.kream.domain.style.model;
 
+import java.util.Collections;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 import com.prgrms.kream.common.model.BaseTimeEntity;
 
@@ -33,6 +37,9 @@ public class Feed extends BaseTimeEntity {
 	@Column(name = "likes", nullable = false, unique = false)
 	private Long likes;
 
+	@Transient
+	private List<Long> productIds;
+
 	@Builder
 	public Feed(Long id, String content, Long authorId, Long likes) {
 		this.id = id;
@@ -51,6 +58,10 @@ public class Feed extends BaseTimeEntity {
 
 	public void decreaseLikes() {
 		this.likes = (likes > 0) ? likes - 1L: 0;
+	}
+
+	public void setProductIds(List<Long> productIds) {
+		this.productIds = Collections.unmodifiableList(productIds);
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/model/FeedProduct.java
+++ b/src/main/java/com/prgrms/kream/domain/style/model/FeedProduct.java
@@ -1,0 +1,40 @@
+package com.prgrms.kream.domain.style.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.prgrms.kream.common.model.BaseTimeEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "feed_product")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedProduct extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "feed_id", nullable = false, unique = false)
+	private Long feedId;
+
+	@Column(name = "product_id", nullable = false, unique = false)
+	private Long productId;
+
+	@Builder
+	public FeedProduct(Long id, Long feedId, Long productId) {
+		this.id = id;
+		this.feedId = feedId;
+		this.productId = productId;
+	}
+
+}

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepository.java
@@ -12,6 +12,6 @@ public interface FeedCustomRepository {
 
 	List<Feed> findAllOrderByCreatedAtDesc(Long cursorId, int pageSize);
 
-	List<Feed> findAllOrderByLikesDesc();
+	List<Feed> findAllOrderByLikesDesc(Long cursorId, int pageSize);
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.prgrms.kream.domain.style.repository;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,9 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class FeedCustomRepositoryImpl implements FeedCustomRepository {
@@ -63,15 +66,40 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
 	}
 
 	@Override
-	public List<Feed> findAllOrderByLikesDesc() {
+	public List<Feed> findAllOrderByLikesDesc(Long cursorId, int pageSize) {
+		Feed feed = jpaQueryFactory
+				.selectFrom(qFeed)
+				.where(eqFeedId(cursorId))
+				.orderBy(qFeed.likes.desc(), qFeed.id.desc())
+				.fetchFirst();
+
+		if (feed == null) {
+			return Collections.emptyList();
+		}
+
 		return jpaQueryFactory
 				.selectFrom(qFeed)
-				.orderBy(qFeed.likes.desc(), qFeed.createdAt.desc())
+				.where(ltLikesOrEqLikesAndLoeFeedId(feed.getLikes(), feed.getId()))
+				.orderBy(qFeed.likes.desc(), qFeed.id.desc())
+				.limit(pageSize+1)
 				.fetch();
 	}
 
 	private BooleanExpression loeFeedId(Long feedId) {
 		return (feedId == null) ? null : qFeed.id.loe(feedId);
+	}
+
+	private BooleanExpression eqFeedId(Long feedId) {
+		return (feedId == null) ? null : qFeed.id.eq(feedId);
+	}
+
+	private BooleanExpression ltLikesOrEqLikesAndLoeFeedId(Long likes, Long feedId) {
+		if (likes == null) {
+			log.error("피드 조회 중 '좋아요' 관련하여 feedId = {}, likes = {} 값에서 오류가 발생했습니다.", feedId, likes);
+			throw new IllegalArgumentException("피드 조회 중 '좋아요' 관련하여 내부적인 오류가 발생했습니다.");
+		}
+
+		return (feedId == null) ? null : qFeed.likes.lt(likes).or(qFeed.likes.eq(likes).and(qFeed.id.loe(feedId)));
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedProductRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedProductRepository.java
@@ -1,8 +1,13 @@
 package com.prgrms.kream.domain.style.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.prgrms.kream.domain.style.model.FeedProduct;
 
 public interface FeedProductRepository extends JpaRepository<FeedProduct, Long> {
+
+	List<FeedProduct> findAllByFeedId(Long feedId);
+
 }

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedProductRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedProductRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.kream.domain.style.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.kream.domain.style.model.FeedProduct;
+
+public interface FeedProductRepository extends JpaRepository<FeedProduct, Long> {
+}

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -53,7 +53,7 @@ public class StyleService {
 
 		// 상품 태그 데이터 삽입
 		if (registerFeedServiceRequest.productsIds() != null) {
-			List<FeedProduct> feedProducts = toFeedProduct(savedFeed.getId(), registerFeedServiceRequest.productsIds());
+			List<FeedProduct> feedProducts = toFeedProducts(savedFeed.getId(), registerFeedServiceRequest.productsIds());
 			feedProductRepository.saveAll(feedProducts);
 		}
 

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -62,10 +62,10 @@ public class StyleService {
 
 	@Transactional(readOnly = true)
 	public GetFeedServiceResponses getTrendingFeeds() {
-		return toGetFeedServiceResponses(
-				feedRepository.findAllOrderByLikesDesc(),
-				-1L
-		);
+		List<Feed> feeds = feedRepository.findAllOrderByLikesDesc();
+		getFeedProductsOnFeeds(feeds);
+
+		return toGetFeedServiceResponses(feeds, -1L);
 	}
 
 	@Transactional(readOnly = true)
@@ -74,11 +74,12 @@ public class StyleService {
 				getFeedServiceRequest.cursorId(),
 				getFeedServiceRequest.pageSize()
 		);
+		getFeedProductsOnFeeds(feeds);
 
 		if (feeds.size() > getFeedServiceRequest.pageSize()) {
 			return toGetFeedServiceResponses(
-					feeds.subList(0, feeds.size()-1),
-					feeds.get(feeds.size()-1).getId()
+					feeds.subList(0, feeds.size() - 1),
+					feeds.get(feeds.size() - 1).getId()
 			);
 		}
 
@@ -92,11 +93,12 @@ public class StyleService {
 				getFeedServiceRequest.cursorId(),
 				getFeedServiceRequest.pageSize()
 		);
+		getFeedProductsOnFeeds(feeds);
 
 		if (feeds.size() > getFeedServiceRequest.pageSize()) {
 			return toGetFeedServiceResponses(
-					feeds.subList(0, feeds.size()-1),
-					feeds.get(feeds.size()-1).getId()
+					feeds.subList(0, feeds.size() - 1),
+					feeds.get(feeds.size() - 1).getId()
 			);
 		}
 
@@ -110,11 +112,12 @@ public class StyleService {
 				getFeedServiceRequest.cursorId(),
 				getFeedServiceRequest.pageSize()
 		);
+		getFeedProductsOnFeeds(feeds);
 
 		if (feeds.size() > getFeedServiceRequest.pageSize()) {
 			return toGetFeedServiceResponses(
-					feeds.subList(0, feeds.size()-1),
-					feeds.get(feeds.size()-1).getId()
+					feeds.subList(0, feeds.size() - 1),
+					feeds.get(feeds.size() - 1).getId()
 			);
 		}
 
@@ -186,6 +189,14 @@ public class StyleService {
 					likeFeedServiceRequest.memberId()
 			);
 		}
+	}
+
+	private void getFeedProductsOnFeeds(List<Feed> feeds) {
+		feeds.forEach(feed ->
+				feed.setProductIds(
+						feedProductRepository.findAllByFeedId(feed.getId()).stream()
+								.map(FeedProduct::getProductId)
+								.toList()));
 	}
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -61,9 +61,19 @@ public class StyleService {
 	}
 
 	@Transactional(readOnly = true)
-	public GetFeedServiceResponses getTrendingFeeds() {
-		List<Feed> feeds = feedRepository.findAllOrderByLikesDesc();
+	public GetFeedServiceResponses getTrendingFeeds(GetFeedServiceRequest getFeedServiceRequest) {
+		List<Feed> feeds = feedRepository.findAllOrderByLikesDesc(
+				getFeedServiceRequest.cursorId(),
+				getFeedServiceRequest.pageSize()
+		);
 		getFeedProductsOnFeeds(feeds);
+
+		if (feeds.size() > getFeedServiceRequest.pageSize()) {
+			return toGetFeedServiceResponses(
+					feeds.subList(0, feeds.size() - 1),
+					feeds.get(feeds.size() - 1).getId()
+			);
+		}
 
 		return toGetFeedServiceResponses(feeds, -1L);
 	}

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -18,8 +18,10 @@ import com.prgrms.kream.domain.style.dto.response.GetFeedServiceResponses;
 import com.prgrms.kream.domain.style.dto.response.RegisterFeedServiceResponse;
 import com.prgrms.kream.domain.style.dto.response.UpdateFeedServiceResponse;
 import com.prgrms.kream.domain.style.model.Feed;
+import com.prgrms.kream.domain.style.model.FeedProduct;
 import com.prgrms.kream.domain.style.model.FeedTag;
 import com.prgrms.kream.domain.style.repository.FeedLikeRepository;
+import com.prgrms.kream.domain.style.repository.FeedProductRepository;
 import com.prgrms.kream.domain.style.repository.FeedRepository;
 import com.prgrms.kream.domain.style.repository.FeedTagRepository;
 
@@ -35,6 +37,8 @@ public class StyleService {
 
 	private final FeedLikeRepository feedLikeRepository;
 
+	private final FeedProductRepository feedProductRepository;
+
 	@Transactional
 	public RegisterFeedServiceResponse register(RegisterFeedServiceRequest registerFeedServiceRequest) {
 		Feed savedFeed = feedRepository.save(
@@ -43,7 +47,15 @@ public class StyleService {
 
 		// 태그 추출 및 데이터 삽입
 		Set<FeedTag> feedTags = TagExtractor.extract(savedFeed);
-		feedTagRepository.saveAll(feedTags);
+		if (!feedTags.isEmpty()) {
+			feedTagRepository.saveAll(feedTags);
+		}
+
+		// 상품 태그 데이터 삽입
+		if (registerFeedServiceRequest.productsIds() != null) {
+			List<FeedProduct> feedProducts = toFeedProduct(savedFeed.getId(), registerFeedServiceRequest.productsIds());
+			feedProductRepository.saveAll(feedProducts);
+		}
 
 		return toRegisterFeedServiceResponse(savedFeed);
 	}

--- a/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
@@ -188,6 +188,24 @@ class StyleServiceTest {
 		assertThat(getFeedServiceResponses.getFeedServiceResponses()).isNotEmpty();
 	}
 
+	@Test
+	@DisplayName("피드에 등록된 상품 태그를 조회할 수 있다.")
+	void testGetFeedProductsOnFeeds() {
+		when(feedRepository.findAllByMember(
+				MEMBER.getId(),
+				getFeedServiceRequest().cursorId(),
+				getFeedServiceRequest().pageSize()
+		)).thenReturn(List.of(FEED));
+		when(feedProductRepository.findAllByFeedId(FEED.getId())).thenReturn(FEED_PRODUCTS);
+
+		GetFeedServiceResponses getFeedServiceResponses = styleService.getAllByMember(
+				getFeedServiceRequest(),
+				MEMBER.getId()
+		);
+
+		assertThat(getFeedServiceResponses.getFeedServiceResponses().get(0).products()).isNotEmpty();
+	}
+
 	private RegisterFeedServiceRequest getRegisterFeedServiceRequest() {
 		return new RegisterFeedServiceRequest(
 				FEED.getContent(),

--- a/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
@@ -25,8 +25,10 @@ import com.prgrms.kream.domain.style.dto.response.RegisterFeedServiceResponse;
 import com.prgrms.kream.domain.style.dto.response.UpdateFeedServiceResponse;
 import com.prgrms.kream.domain.style.model.Feed;
 import com.prgrms.kream.domain.style.model.FeedLike;
+import com.prgrms.kream.domain.style.model.FeedProduct;
 import com.prgrms.kream.domain.style.model.FeedTag;
 import com.prgrms.kream.domain.style.repository.FeedLikeRepository;
+import com.prgrms.kream.domain.style.repository.FeedProductRepository;
 import com.prgrms.kream.domain.style.repository.FeedRepository;
 import com.prgrms.kream.domain.style.repository.FeedTagRepository;
 
@@ -42,6 +44,9 @@ class StyleServiceTest {
 
 	@Mock
 	private FeedLikeRepository feedLikeRepository;
+
+	@Mock
+	private FeedProductRepository feedProductRepository;
 
 	@InjectMocks
 	private StyleService styleService;
@@ -65,15 +70,31 @@ class StyleServiceTest {
 	private static final Set<FeedTag> FEED_TAGS = TagExtractor.extract(FEED);
 
 	private static final FeedLike FEED_LIKE = FeedLike.builder()
+			.id(1L)
 			.feedId(FEED.getId())
 			.memberId(MEMBER.getId())
 			.build();
+
+	private static final List<FeedProduct> FEED_PRODUCTS = List.of(
+			FeedProduct.builder()
+					.id(1L)
+					.feedId(FEED.getId())
+					.productId(1L)
+					.build(),
+			FeedProduct.builder()
+					.id(2L)
+					.feedId(FEED.getId())
+					.productId(2L)
+					.build()
+	);
 
 	@Test
 	@DisplayName("피드를 등록할 수 있다.")
 	void testRegister() {
 		when(feedRepository.save(any())).thenReturn(FEED);
 		when(feedTagRepository.saveAll(any())).thenReturn(FEED_TAGS.stream().toList());
+		when(feedProductRepository.saveAll(any())).thenReturn(FEED_PRODUCTS);
+
 		RegisterFeedServiceResponse feedResponse = styleService.register(getRegisterFeedServiceRequest());
 
 		assertThat(feedResponse.id()).isEqualTo(1L);
@@ -168,7 +189,13 @@ class StyleServiceTest {
 	}
 
 	private RegisterFeedServiceRequest getRegisterFeedServiceRequest() {
-		return new RegisterFeedServiceRequest(FEED.getContent(), MEMBER.getId());
+		return new RegisterFeedServiceRequest(
+				FEED.getContent(),
+				MEMBER.getId(),
+				FEED_PRODUCTS.stream()
+						.map(FeedProduct::getProductId)
+						.toList()
+		);
 	}
 
 	private GetFeedServiceRequest getFeedServiceRequest() {

--- a/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.prgrms.kream.domain.member.model.Authority;
@@ -91,12 +92,15 @@ class StyleServiceTest {
 	@Test
 	@DisplayName("피드를 등록할 수 있다.")
 	void testRegister() {
-		when(feedRepository.save(any())).thenReturn(FEED);
-		when(feedTagRepository.saveAll(any())).thenReturn(FEED_TAGS.stream().toList());
-		when(feedProductRepository.saveAll(any())).thenReturn(FEED_PRODUCTS);
+		when(feedRepository.save(any(Feed.class))).thenReturn(FEED);
+		when(feedTagRepository.saveAll(Mockito.<FeedTag>anyIterable())).thenReturn(FEED_TAGS.stream().toList());
+		when(feedProductRepository.saveAll(Mockito.<FeedProduct>anyIterable())).thenReturn(FEED_PRODUCTS);
 
 		RegisterFeedServiceResponse feedResponse = styleService.register(getRegisterFeedServiceRequest());
 
+		verify(feedRepository).save(any(Feed.class));
+		verify(feedTagRepository).saveAll(Mockito.<FeedTag>anyIterable());
+		verify(feedProductRepository).saveAll(Mockito.<FeedProduct>anyIterable());
 		assertThat(feedResponse.id()).isEqualTo(1L);
 	}
 
@@ -112,9 +116,8 @@ class StyleServiceTest {
 	@Test
 	@DisplayName("피드를 수정할 수 있다.")
 	void testUpdate() {
-		when(feedRepository.save(any())).thenReturn(FEED);
-		when(feedTagRepository.saveAll(any())).thenReturn(FEED_TAGS.stream().toList());
-		styleService.register(getRegisterFeedServiceRequest());
+		when(feedRepository.save(any(Feed.class))).thenReturn(FEED);
+		when(feedTagRepository.saveAll(Mockito.<FeedTag>anyIterable())).thenReturn(FEED_TAGS.stream().toList());
 		when(feedRepository.findById(FEED.getId())).thenReturn(Optional.of(FEED));
 
 		UpdateFeedServiceResponse updateFeedServiceResponse =
@@ -123,6 +126,10 @@ class StyleServiceTest {
 						getUpdateFeedServiceRequest("이 피드의 태그는 총 #한개 입니다.")
 				);
 
+		verify(feedRepository).findById(FEED.getId());
+		verify(feedRepository).save(any(Feed.class));
+		verify(feedTagRepository).deleteAllByFeedId(FEED.getId());
+		verify(feedTagRepository).saveAll(Mockito.<FeedTag>anyIterable());
 		assertThat(updateFeedServiceResponse.id()).isEqualTo(FEED.getId());
 	}
 
@@ -159,16 +166,22 @@ class StyleServiceTest {
 	@Test
 	@DisplayName("태그 기준으로 피드 식별자를 조회할 수 있다.")
 	void testGetFeedsByTag() {
+		String tag = FEED_TAGS.stream().findAny().get().getTag();
+
 		when(feedRepository.findAllByTag(
-				FEED_TAGS.stream().findAny().get().getTag(),
+				tag,
 				getFeedServiceRequest().cursorId(),
 				getFeedServiceRequest().pageSize()
 		)).thenReturn(List.of(FEED));
 
 		GetFeedServiceResponses getFeedServiceResponses = styleService.getAllByTag(
 				getFeedServiceRequest(),
-				FEED_TAGS.stream().toList().get(0).getTag());
+				tag);
 
+		verify(feedRepository).findAllByTag(
+				tag,
+				getFeedServiceRequest().cursorId(),
+				getFeedServiceRequest().pageSize());
 		assertThat(getFeedServiceResponses.getFeedServiceResponses()).isNotEmpty();
 	}
 
@@ -185,6 +198,10 @@ class StyleServiceTest {
 				getFeedServiceRequest(),
 				MEMBER.getId());
 
+		verify(feedRepository).findAllByMember(
+				MEMBER.getId(),
+				getFeedServiceRequest().cursorId(),
+				getFeedServiceRequest().pageSize());
 		assertThat(getFeedServiceResponses.getFeedServiceResponses()).isNotEmpty();
 	}
 
@@ -203,6 +220,7 @@ class StyleServiceTest {
 				MEMBER.getId()
 		);
 
+		verify(feedProductRepository).findAllByFeedId(any(Long.class));
 		assertThat(getFeedServiceResponses.getFeedServiceResponses().get(0).products()).isNotEmpty();
 	}
 


### PR DESCRIPTION
### ⛏ 작업 사항
- FeedProduct 엔티티 및 FeedProductRepository 구현
- Feed 엔티티에 필드 추가
  - 상품 태그 (즉, 상품 ID값을 가지는 리스트)
  - 해당 필드는 DB에 저장하지 않도록 @Transient
- DTO에 Product 식별자 리스트 추가
- 상품 태그 등록, 조회 관련 단위 테스트 코드 추가

### 📝 작업 요약
- 피드의 상품 태그 등록, 조회 기능 구현

### 💡 관련 이슈
- Resolved : [SHK-166], [SHK-179]


[SHK-166]: https://shoekream.atlassian.net/browse/SHK-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-179]: https://shoekream.atlassian.net/browse/SHK-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ