### PR TITLE
[SHK-177] FeedProduct 수정 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/StyleMapper.java
@@ -159,11 +159,11 @@ public class StyleMapper {
 	}
 
 	public static UpdateFeedFacadeRequest toUpdateFeedFacadeRequest(UpdateFeedRequest updateFeedRequest) {
-		return new UpdateFeedFacadeRequest(updateFeedRequest.content());
+		return new UpdateFeedFacadeRequest(updateFeedRequest.content(), updateFeedRequest.productIds());
 	}
 
 	public static UpdateFeedServiceRequest toUpdateFeedServiceRequest(UpdateFeedFacadeRequest updateFeedFacadeRequest) {
-		return new UpdateFeedServiceRequest(updateFeedFacadeRequest.content());
+		return new UpdateFeedServiceRequest(updateFeedFacadeRequest.content(), updateFeedFacadeRequest.productIds());
 	}
 
 	public static UpdateFeedServiceResponse toUpdateFeedServiceResponse(Feed feed) {

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/UpdateFeedFacadeRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/UpdateFeedFacadeRequest.java
@@ -1,6 +1,9 @@
 package com.prgrms.kream.domain.style.dto.request;
 
+import java.util.List;
+
 public record UpdateFeedFacadeRequest(
-		String content
+		String content,
+		List<Long> productIds
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/UpdateFeedRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/UpdateFeedRequest.java
@@ -1,9 +1,13 @@
 package com.prgrms.kream.domain.style.dto.request;
 
+import java.util.List;
+
 import javax.validation.constraints.NotEmpty;
 
 public record UpdateFeedRequest(
 		@NotEmpty(message = "피드 본문이 비어있을 수 없습니다.")
-		String content
+		String content,
+
+		List<Long> productIds
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/dto/request/UpdateFeedServiceRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/style/dto/request/UpdateFeedServiceRequest.java
@@ -1,6 +1,9 @@
 package com.prgrms.kream.domain.style.dto.request;
 
+import java.util.List;
+
 public record UpdateFeedServiceRequest(
-		String content
+		String content,
+		List<Long> productIds
 ) {
 }

--- a/src/main/java/com/prgrms/kream/domain/style/repository/FeedProductRepository.java
+++ b/src/main/java/com/prgrms/kream/domain/style/repository/FeedProductRepository.java
@@ -3,11 +3,17 @@ package com.prgrms.kream.domain.style.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.prgrms.kream.domain.style.model.FeedProduct;
 
 public interface FeedProductRepository extends JpaRepository<FeedProduct, Long> {
 
 	List<FeedProduct> findAllByFeedId(Long feedId);
+
+	@Modifying
+	@Query("delete from FeedProduct feedProduct where feedProduct.feedId = :feedId")
+	void deleteAllByFeedId(Long feedId);
 
 }

--- a/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
+++ b/src/main/java/com/prgrms/kream/domain/style/service/StyleService.java
@@ -141,10 +141,15 @@ public class StyleService {
 					feed.updateContent(updateFeedServiceRequest.content());
 					Feed entity = feedRepository.save(feed);
 
+					// 피드 태그 삭제 후 재등록
 					feedTagRepository.deleteAllByFeedId(entity.getId());
-
 					Set<FeedTag> feedTags = TagExtractor.extract(entity);
 					feedTagRepository.saveAll(feedTags);
+
+					// 피드 상품태그 삭제 후 재등록
+					feedProductRepository.deleteAllByFeedId(entity.getId());
+					List<FeedProduct> feedProducts = toFeedProducts(entity.getId(), updateFeedServiceRequest.productIds());
+					feedProductRepository.saveAll(feedProducts);
 
 					return entity;
 				})
@@ -160,6 +165,7 @@ public class StyleService {
 					// 관련 테이블의 레코드 삭제 (Cascade)
 					feedTagRepository.deleteAllByFeedId(feed.getId());
 					feedLikeRepository.deleteAllByFeedId(feed.getId());
+					feedProductRepository.deleteAllByFeedId(feed.getId());
 					feedRepository.delete(feed);
 				});
 	}

--- a/src/test/java/com/prgrms/kream/domain/style/controller/StyleControllerTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/controller/StyleControllerTest.java
@@ -4,6 +4,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -68,7 +70,8 @@ class StyleControllerTest extends MysqlTestContainer {
 		mockMvc.perform(MockMvcRequestBuilders.multipart("/api/v1/feed")
 						.file(mockImage)
 						.param("content", "이 피드의 태그는 #총 #두개 입니다.")
-						.param("authorId", String.valueOf(member.getId())))
+						.param("authorId", String.valueOf(member.getId()))
+						.param("productIds", "1, 2, 3"))
 				.andExpect(status().isCreated())
 				.andDo(print());
 	}
@@ -80,7 +83,7 @@ class StyleControllerTest extends MysqlTestContainer {
 		mockMvc.perform(put("/api/v1/feed/1")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(
-								new UpdateFeedRequest("이 피드의 태그는 총 #한개 입니다.")
+								new UpdateFeedRequest("이 피드의 태그는 총 #한개 입니다.", List.of(4L, 5L, 6L))
 						)))
 				.andExpect(status().isOk())
 				.andDo(print());

--- a/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
+++ b/src/test/java/com/prgrms/kream/domain/style/service/StyleServiceTest.java
@@ -3,6 +3,7 @@ package com.prgrms.kream.domain.style.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -117,7 +118,8 @@ class StyleServiceTest {
 	@DisplayName("피드를 수정할 수 있다.")
 	void testUpdate() {
 		when(feedRepository.save(any(Feed.class))).thenReturn(FEED);
-		when(feedTagRepository.saveAll(Mockito.<FeedTag>anyIterable())).thenReturn(FEED_TAGS.stream().toList());
+		when(feedTagRepository.saveAll(Mockito.<FeedTag>anyIterable())).thenReturn(List.copyOf(FEED_TAGS));
+		when(feedProductRepository.saveAll(Mockito.<FeedProduct>anyIterable())).thenReturn(List.copyOf(FEED_PRODUCTS));
 		when(feedRepository.findById(FEED.getId())).thenReturn(Optional.of(FEED));
 
 		UpdateFeedServiceResponse updateFeedServiceResponse =
@@ -130,6 +132,8 @@ class StyleServiceTest {
 		verify(feedRepository).save(any(Feed.class));
 		verify(feedTagRepository).deleteAllByFeedId(FEED.getId());
 		verify(feedTagRepository).saveAll(Mockito.<FeedTag>anyIterable());
+		verify(feedProductRepository).deleteAllByFeedId(FEED.getId());
+		verify(feedProductRepository).saveAll(Mockito.<FeedProduct>anyIterable());
 		assertThat(updateFeedServiceResponse.id()).isEqualTo(FEED.getId());
 	}
 
@@ -239,7 +243,20 @@ class StyleServiceTest {
 	}
 
 	private UpdateFeedServiceRequest getUpdateFeedServiceRequest(String content) {
-		return new UpdateFeedServiceRequest(content);
+		List<FeedProduct> updatedFeedProducts = new ArrayList<>(FEED_PRODUCTS);
+		updatedFeedProducts.add(
+				FeedProduct.builder()
+						.id(3L)
+						.feedId(FEED.getId())
+						.productId(3L)
+						.build()
+		);
+
+		return new UpdateFeedServiceRequest(
+				content,
+				updatedFeedProducts.stream()
+						.map(FeedProduct::getProductId)
+						.toList());
 	}
 
 	private LikeFeedServiceRequest getLikeFeedServiceRequest() {


### PR DESCRIPTION
### ⛏ 작업 사항
- FeedProductRepository 삭제 메서드 정의
- 피드 수정(Update) 시 기존 상품태그 삭제 및 새롭게 등록하도록 추가
- 피드 삭제(Delete) 시 피드 식별자 기준 상품태그 삭제하도록 추가
- UpdateRequest DTO에 productIds(상품태그 리스트) 추가

### 📝 작업 요약
- 피드의 상품태그 수정 기능 구현 및 테스트

### 💡 관련 이슈
- Resolved : [SHK-178]


[SHK-178]: https://shoekream.atlassian.net/browse/SHK-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ