### PR TITLE
[SHK-12] Member 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/kream/common/jwt/JwtUtil.java
+++ b/src/main/java/com/prgrms/kream/common/jwt/JwtUtil.java
@@ -1,5 +1,7 @@
 package com.prgrms.kream.common.jwt;
 
+import java.util.Objects;
+
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,5 +16,9 @@ public class JwtUtil {
 			throw new AccessDeniedException("잘못된 접근입니다.");
 		}
 		return (Long)authentication.getPrincipal();
+	}
+
+	public static boolean isValidAccess(Long memberId) {
+		return Objects.equals(JwtUtil.getMemberId(), memberId);
 	}
 }

--- a/src/main/java/com/prgrms/kream/common/mapper/MemberMapper.java
+++ b/src/main/java/com/prgrms/kream/common/mapper/MemberMapper.java
@@ -5,8 +5,13 @@ import static lombok.AccessLevel.*;
 import java.util.List;
 
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.request.MemberUpdateFacadeRequest;
+import com.prgrms.kream.domain.member.dto.request.MemberUpdateRequest;
+import com.prgrms.kream.domain.member.dto.request.MemberUpdateServiceRequest;
 import com.prgrms.kream.domain.member.dto.response.MemberGetFacadeResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberGetResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberUpdateResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberUpdateServiceResponse;
 import com.prgrms.kream.domain.member.model.Member;
 
 import lombok.NoArgsConstructor;
@@ -57,9 +62,47 @@ public class MemberMapper {
 				.name(memberGetFacadeResponse.name())
 				.email(memberGetFacadeResponse.email())
 				.phone(memberGetFacadeResponse.phone())
-				.isMale(memberGetFacadeResponse.isMale())
-				.authority(memberGetFacadeResponse.authority())
 				.imagePaths(imagePaths)
 				.build();
+	}
+
+	public static MemberUpdateFacadeRequest toMemberUpdateFacadeRequest(
+			Long memberId,
+			MemberUpdateRequest memberUpdateRequest
+	) {
+		return new MemberUpdateFacadeRequest(
+				memberId,
+				memberUpdateRequest.name(),
+				memberUpdateRequest.phone(),
+				memberUpdateRequest.password(),
+				memberUpdateRequest.imageFile()
+		);
+	}
+
+	public static MemberUpdateServiceResponse toMemberUpdateServiceResponse(Member member) {
+		return new MemberUpdateServiceResponse(member.getId(), member.getName(), member.getPhone());
+	}
+
+	public static MemberUpdateServiceRequest toMemberUpdateServiceRequest(
+			MemberUpdateFacadeRequest memberUpdateFacadeRequest
+	) {
+		return new MemberUpdateServiceRequest(
+				memberUpdateFacadeRequest.id(),
+				memberUpdateFacadeRequest.name(),
+				memberUpdateFacadeRequest.phone(),
+				memberUpdateFacadeRequest.password()
+		);
+	}
+
+	public static MemberUpdateResponse toMemberUpdateResponse(
+			MemberUpdateServiceResponse memberUpdateServiceResponse,
+			List<String> imagePaths
+	) {
+		return new MemberUpdateResponse(
+				memberUpdateServiceResponse.id(),
+				memberUpdateServiceResponse.name(),
+				memberUpdateServiceResponse.phone(),
+				imagePaths
+		);
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prgrms/kream/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.prgrms.kream.domain.member.controller;
 
+import static com.prgrms.kream.common.mapper.MemberMapper.*;
 import static org.springframework.http.HttpStatus.*;
 
 import javax.servlet.http.Cookie;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,8 +22,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.prgrms.kream.common.api.ApiResponse;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.request.MemberUpdateRequest;
 import com.prgrms.kream.domain.member.dto.response.MemberGetResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberUpdateResponse;
 import com.prgrms.kream.domain.member.facade.MemberFacade;
 
 import lombok.RequiredArgsConstructor;
@@ -74,5 +78,16 @@ public class MemberController {
 	@ResponseStatus(OK)
 	public ApiResponse<MemberGetResponse> get(@PathVariable Long id) {
 		return ApiResponse.of(memberFacade.get(id));
+	}
+
+	@PostMapping("/{id}")
+	@ResponseStatus(OK)
+	public ApiResponse<MemberUpdateResponse> update(
+			@PathVariable Long id,
+			@ModelAttribute @Valid MemberUpdateRequest memberUpdateRequest
+	) {
+		return ApiResponse.of(
+				memberFacade.updateMember(toMemberUpdateFacadeRequest(id, memberUpdateRequest))
+		);
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberUpdateFacadeRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberUpdateFacadeRequest.java
@@ -1,0 +1,12 @@
+package com.prgrms.kream.domain.member.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record MemberUpdateFacadeRequest(
+		Long id,
+		String name,
+		String phone,
+		String password,
+		MultipartFile imageFile
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.prgrms.kream.domain.member.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
+
+// @Builder
+public record MemberUpdateRequest(
+		@NotBlank(message = "비밀번호는 빈값일 수 없습니다")
+		@Length(max = 20, message = "이름은 20자 이내여야 합니다")
+		String name,
+
+		@NotBlank(message = "핸드폰 번호는 빈값일 수 없습니다")
+		@Length(min = 11, max = 11, message = "번호는 11자여야 합니다")
+		String phone,
+
+		@NotBlank(message = "비밀번호는 빈값일 수 없습니다")
+		@Length(min = 8, max = 16, message = "비밀번호는 8 ~ 16자 이내여야 합니다")
+		String password,
+
+		MultipartFile imageFile
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberUpdateServiceRequest.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/request/MemberUpdateServiceRequest.java
@@ -1,0 +1,9 @@
+package com.prgrms.kream.domain.member.dto.request;
+
+public record MemberUpdateServiceRequest(
+		Long id,
+		String name,
+		String phone,
+		String password
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberUpdateResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberUpdateResponse.java
@@ -2,13 +2,9 @@ package com.prgrms.kream.domain.member.dto.response;
 
 import java.util.List;
 
-import lombok.Builder;
-
-@Builder
-public record MemberGetResponse(
+public record MemberUpdateResponse(
 		Long id,
 		String name,
-		String email,
 		String phone,
 		List<String> imagePaths
 ) {

--- a/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberUpdateServiceResponse.java
+++ b/src/main/java/com/prgrms/kream/domain/member/dto/response/MemberUpdateServiceResponse.java
@@ -1,0 +1,8 @@
+package com.prgrms.kream.domain.member.dto.response;
+
+public record MemberUpdateServiceResponse(
+		Long id,
+		String name,
+		String phone
+) {
+}

--- a/src/main/java/com/prgrms/kream/domain/member/facade/MemberFacade.java
+++ b/src/main/java/com/prgrms/kream/domain/member/facade/MemberFacade.java
@@ -1,20 +1,25 @@
 package com.prgrms.kream.domain.member.facade;
 
 import static com.prgrms.kream.common.mapper.MemberMapper.*;
+import static com.prgrms.kream.domain.image.model.DomainType.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.prgrms.kream.domain.image.model.DomainType;
 import com.prgrms.kream.domain.image.service.ImageService;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.request.MemberUpdateFacadeRequest;
 import com.prgrms.kream.domain.member.dto.response.MemberGetFacadeResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberGetResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberLoginResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberUpdateResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberUpdateServiceResponse;
 import com.prgrms.kream.domain.member.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
@@ -36,7 +41,21 @@ public class MemberFacade {
 	@Transactional(readOnly = true)
 	public MemberGetResponse get(Long memberId) {
 		MemberGetFacadeResponse memberGetFacadeResponse = memberService.get(memberId);
-		List<String> imagePaths = imageService.getAll(memberId, DomainType.MEMBER);
+		List<String> imagePaths = imageService.getAll(memberId, MEMBER);
 		return toMemberGetResponse(memberGetFacadeResponse, imagePaths);
+	}
+
+	@Transactional
+	public MemberUpdateResponse updateMember(MemberUpdateFacadeRequest memberUpdateFacadeRequest) {
+		MemberUpdateServiceResponse memberUpdateServiceResponse =
+				memberService.updateMember(toMemberUpdateServiceRequest(memberUpdateFacadeRequest));
+
+		List<String> imagePaths = Collections.emptyList();
+		imageService.deleteAllByReference(memberUpdateFacadeRequest.id(), MEMBER);
+		if (!Objects.isNull(memberUpdateFacadeRequest.imageFile())) {
+			imageService.register(List.of(memberUpdateFacadeRequest.imageFile()), memberUpdateFacadeRequest.id(), MEMBER);
+			imagePaths = imageService.getAll(memberUpdateFacadeRequest.id(), MEMBER);
+		}
+		return toMemberUpdateResponse(memberUpdateServiceResponse, imagePaths);
 	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/model/Member.java
+++ b/src/main/java/com/prgrms/kream/domain/member/model/Member.java
@@ -71,4 +71,9 @@ public class Member extends BaseTimeEntity {
 		return !password.isValidPassword(inputPassword);
 	}
 
+	public void updateMember(String name, String phone, String password) {
+		this.name = name;
+		this.phone = new Phone(phone);
+		this.password = new Password(password);
+	}
 }

--- a/src/main/java/com/prgrms/kream/domain/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/kream/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.prgrms.kream.domain.member.service;
 
+import static com.prgrms.kream.common.jwt.JwtUtil.*;
 import static com.prgrms.kream.common.mapper.MemberMapper.*;
 
 import java.util.Objects;
@@ -13,13 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.kream.common.exception.DuplicatedEmailException;
 import com.prgrms.kream.common.jwt.Jwt;
-import com.prgrms.kream.common.jwt.JwtUtil;
 import com.prgrms.kream.common.mapper.MemberMapper;
 import com.prgrms.kream.domain.member.dto.request.MemberLoginRequest;
 import com.prgrms.kream.domain.member.dto.request.MemberRegisterRequest;
+import com.prgrms.kream.domain.member.dto.request.MemberUpdateServiceRequest;
 import com.prgrms.kream.domain.member.dto.response.MemberGetFacadeResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberLoginResponse;
 import com.prgrms.kream.domain.member.dto.response.MemberRegisterResponse;
+import com.prgrms.kream.domain.member.dto.response.MemberUpdateServiceResponse;
 import com.prgrms.kream.domain.member.model.Member;
 import com.prgrms.kream.domain.member.repository.MemberRepository;
 
@@ -63,12 +65,30 @@ public class MemberService {
 
 	@Transactional(readOnly = true)
 	public MemberGetFacadeResponse get(Long id) {
-		if (!Objects.equals(JwtUtil.getMemberId(), id)) {
+		if (!Objects.equals(getMemberId(), id)) {
 			throw new AccessDeniedException("잘못된 접근입니다");
 		}
 
 		Member member = memberRepository.findById(id)
 				.orElseThrow(() -> new EntityNotFoundException("존재하지 않은 회원입니다."));
 		return toMemberGetFacadeResponse(member);
+	}
+
+	@Transactional
+	public MemberUpdateServiceResponse updateMember(MemberUpdateServiceRequest memberUpdateServiceRequest) {
+		if (!isValidAccess(memberUpdateServiceRequest.id())) {
+			throw new AccessDeniedException("잘못된 접근입니다");
+		}
+
+		Member member = memberRepository.findById(memberUpdateServiceRequest.id())
+				.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+
+		member.updateMember(
+				memberUpdateServiceRequest.name(),
+				memberUpdateServiceRequest.phone(),
+				memberUpdateServiceRequest.password()
+		);
+
+		return toMemberUpdateServiceResponse(member);
 	}
 }

--- a/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/kream/domain/member/controller/MemberControllerTest.java
@@ -2,11 +2,14 @@ package com.prgrms.kream.domain.member.controller;
 
 import static com.prgrms.kream.domain.image.model.DomainType.*;
 import static com.prgrms.kream.domain.member.model.Authority.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.io.InputStream;
+import java.net.URL;
 import java.util.List;
 
 import javax.servlet.http.Cookie;
@@ -20,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -27,7 +32,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.kream.MysqlTestContainer;
 import com.prgrms.kream.domain.image.model.Image;
@@ -45,6 +53,11 @@ class MemberControllerTest extends MysqlTestContainer {
 	@Autowired
 	private MockMvc mockMvc;
 
+	@MockBean
+	AmazonS3 amazonS3;
+
+	private final String bucket = "s3test";
+
 	@Value("${jwt.accessToken}")
 	private String accessToken;
 
@@ -57,9 +70,11 @@ class MemberControllerTest extends MysqlTestContainer {
 	@Autowired
 	private ImageRepository imageRepository;
 
+	static Long memberId;
+
 	@BeforeEach
 	void setUp() {
-		memberRepository.save(
+		Member member = memberRepository.save(
 				Member.builder()
 						.email("hello@naver.com")
 						.name("name")
@@ -69,28 +84,21 @@ class MemberControllerTest extends MysqlTestContainer {
 						.authority(ROLE_USER)
 						.build());
 
+		memberId = member.getId();
+
 		imageRepository.save(
 				Image.builder()
-						.referenceId(1L)
+						.referenceId(memberId)
 						.domainType(MEMBER)
 						.fullPath("/path/test1")
 						.originalName("profile1")
 						.build()
 		);
 
-		imageRepository.save(
-				Image.builder()
-						.referenceId(1L)
-						.domainType(MEMBER)
-						.fullPath("/path/test2")
-						.originalName("profile2")
-						.build()
-		);
-
 		SecurityContext context = SecurityContextHolder.getContext();
 		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
 				new UsernamePasswordAuthenticationToken(
-						1L, null, List.of(new SimpleGrantedAuthority(ROLE_USER.name()))
+						memberId, null, List.of(new SimpleGrantedAuthority(ROLE_USER.name()))
 				);
 
 		context.setAuthentication(usernamePasswordAuthenticationToken);
@@ -111,7 +119,7 @@ class MemberControllerTest extends MysqlTestContainer {
 						.contentType(APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(memberRegisterRequest))
 				).andExpect(status().isCreated())
-				.andExpect(jsonPath("$.data.id").value(Matchers.any(Number.class)))
+				.andExpect(jsonPath("$.data.id").value(memberId + 1))
 				.andDo(print())
 		;
 	}
@@ -156,16 +164,42 @@ class MemberControllerTest extends MysqlTestContainer {
 	@Test
 	@DisplayName("사용자 정보 조회 성공")
 	void get_success() throws Exception {
-		mockMvc.perform(get("/api/v1/member/1"))
+		mockMvc.perform(get("/api/v1/member/{id}", memberId))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.data.id").value(1))
+				.andExpect(jsonPath("$.data.id").value(memberId))
 				.andExpect(jsonPath("$.data.name").value("name"))
 				.andExpect(jsonPath("$.data.email").value("hello@naver.com"))
 				.andExpect(jsonPath("$.data.phone").value("01012345678"))
-				.andExpect(jsonPath("$.data.isMale").value(true))
-				.andExpect(jsonPath("$.data.authority").value(ROLE_USER.name()))
-				.andExpect(jsonPath("$.data.imagePaths[0]").value("/path/test1"))
-				.andExpect(jsonPath("$.data.imagePaths[1]").value("/path/test2"))
+				.andExpect(jsonPath("$.data.imagePaths[0]").value("/path/test1"));
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 성공")
+	void update_success() throws Exception {
+		MockMultipartFile mockImage = new MockMultipartFile(
+				"imageFile",
+				"test.png",
+				IMAGE_PNG_VALUE,
+				"imageFile".getBytes()
+		);
+
+		when(amazonS3.getUrl(eq(bucket), anyString()))
+				.thenReturn(new URL("http://testURL"));
+
+		mockMvc.perform(MockMvcRequestBuilders.multipart("/api/v1/member/{memberId}", memberId)
+						.file(mockImage)
+						.param("name", "updatedName")
+						.param("phone", "01023456789")
+						.param("password", "changed!12345")
+				)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.id").value(memberId))
+				.andExpect(jsonPath("$.data.name").value("updatedName"))
+				.andExpect(jsonPath("$.data.phone").value("01023456789"))
+				.andExpect(jsonPath("$.data.imagePaths[0]").value("http://testURL"))
 				.andDo(print());
+
+		verify(amazonS3, times(1)).putObject(eq(bucket), anyString(), any(InputStream.class), any(ObjectMetadata.class));
+		verify(amazonS3, times(1)).getUrl(eq(bucket), anyString());
 	}
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- Member update method 추가
- layer별 필요한 `dto` 추가
- `JwtUtil` 유효한 사용자 검증 method(`isValidAccess`) 추가

### 📝 작업 요약
- `Member` 정보 수정 기능 구현 및 테스트

### 💡 관련 이슈
- Resolved : [SHK-198], [SHK-199]


[SHK-198]: https://shoekream.atlassian.net/browse/SHK-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHK-199]: https://shoekream.atlassian.net/browse/SHK-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ